### PR TITLE
gitignore에서 docs 제외를 없애고 단위 실험 워커 수를 낮춘다

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,6 @@ dist
 *.egg-info
 *_out.*
 .python-version
-docs/*
-!docs/*.md
 
 .claude
 .venv

--- a/configs/unit.py
+++ b/configs/unit.py
@@ -12,7 +12,7 @@ from configs.schema import ExperimentConfig
 def get_config() -> ExperimentConfig:
     cfg = get_base()
     cfg.data.limit = 3000  # 전체 8,979장에서 균등 간격 추출 (seedmap._subsample)
-    cfg.data.num_workers = 6  # arm 4개 x 6 = 24 워커 (32 코어)
+    cfg.data.num_workers = 4  # arm 4개 x 4 = 16 워커 — 시스템에 절반을 남긴다
     cfg.train.epochs = 10
     cfg.train.devices = "1"
     cfg.train.accumulate = 4  # 유효 배치 4 — 짧은 실행에서는 step 수가 곧 학습량


### PR DESCRIPTION
## .gitignore

`docs/*` + `!docs/*.md` 두 줄을 지웠다. 이제 `docs/` 아래 모든 파일이 그냥 추적된다.

설계 문서가 코드와 함께 버전 관리되는 것이 기본인데, 예외 규칙이 남아 있으면 문서를
새로 만들 때마다 조용히 추적에서 빠진다. 실제로 직전 PR에서 새 문서 다섯 개가 전부
무시되고 있었다.

현재 `docs/`에는 md 파일 일곱 개뿐이라 새로 노출되는 파일은 없다.

## configs/unit.py

단위 실험의 `num_workers`를 6에서 4로 낮췄다. arm 4개 기준 24 워커에서 16 워커가 되어
32 코어의 절반을 시스템에 남긴다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)