### PR TITLE
루프 자동화 — 게이트·자동 판정·디스패처

### DIFF
--- a/gate_baseline.json
+++ b/gate_baseline.json
@@ -1,0 +1,64 @@
+{
+  "updated": "2026-08-10",
+  "note": [
+    "게이트는 고정된 검사 목록이 아니라 '지금까지 배운 실패 양식'의 누적이다.",
+    "새로운 방식으로 깨지는 것을 볼 때마다 여기에 검사를 하나 추가한다 (SKILL 16절).",
+    "why 는 '이 검사가 어떤 사고를 막는가'다. 답할 수 없는 검사는 지운다.",
+    "bounds 의 min 은 --update 로 래칫된다 — 좋아지면 따라 올라가고, 내리려면 사람이 --force."
+  ],
+  "checks": [
+    {
+      "id": "pytest",
+      "kind": "command",
+      "cmd": [".venv/bin/python", "-m", "pytest", "tests/", "-q", "-m", "not slow"],
+      "why": "인코더 불변식·매칭·RoPE·디코더·지표의 계약. 이게 깨지면 아래 수치는 의미가 없다",
+      "since": "초기"
+    },
+    {
+      "id": "ruff",
+      "kind": "command",
+      "cmd": [".venv/bin/python", "-m", "ruff", "check", "."],
+      "why": "린트. 죽은 import·미사용 변수는 대개 리팩터가 덜 끝났다는 신호다",
+      "since": "초기"
+    },
+    {
+      "id": "format",
+      "kind": "command",
+      "cmd": [".venv/bin/python", "-m", "ruff", "format", "--check", "."],
+      "why": "포맷 미적용 상태로 병합되면 다음 PR의 diff가 오염된다",
+      "since": "초기"
+    },
+    {
+      "id": "configs",
+      "kind": "configs",
+      "why": "config의 path+name 오타는 학습 몇 시간 뒤가 아니라 여기서 잡혀야 한다",
+      "since": "초기"
+    },
+    {
+      "id": "install",
+      "kind": "install",
+      "why": "editable 설치가 worktree를 가리키면 `python scripts/*.py`가 남의 코드로 돈다. `-m` 실행(학습)은 cwd가 우선해 멀쩡하므로 학습만 보면 끝까지 눈치채지 못한다. 실제로 4커밋 전 worktree를 가리키고 있었다",
+      "since": "2026-08-10 (E06 D트랙 도중 발견)"
+    },
+    {
+      "id": "ceiling_gt",
+      "kind": "decode",
+      "cache": "gt_val320",
+      "config": "configs.base",
+      "count": 120,
+      "bounds": { "f1": { "min": 0.95 } },
+      "why": "GT를 인코딩해 넣었는데 디코더가 복원하지 못하면 학습과 무관하게 그 변경이 틀렸다. 천장 실측 0.976 (E00)",
+      "since": "E00"
+    },
+    {
+      "id": "model_regress",
+      "cache": "reff_ep11_val200",
+      "kind": "decode",
+      "config": "configs.base",
+      "count": 120,
+      "bounds": { "f1": { "min": 0.09 } },
+      "why": "천장(완벽한 입력)만 보면 약한 입력에서의 퇴행을 놓친다. 기본값(radius=2) 실측 0.1012 (E06)",
+      "since": "E06"
+    }
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,8 @@ torchvision = { index = "pytorch-cu124" }
 [tool.ruff]
 line-length = 100
 target-version = "py311"
+# 설계 문서의 코드 예시는 읽기 좋게 손으로 줄을 접어 둔 것이다 — 포매터가 펴면 diff만 커진다.
+extend-exclude = ["docs", ".claude"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "W", "UP", "B"]

--- a/scripts/dispatch.py
+++ b/scripts/dispatch.py
@@ -1,0 +1,207 @@
+"""대기열의 다음 라운드를 자원이 비는 대로 실행하고 판정까지 한다 (improve-loop · 디스패처).
+
+`watch.sh` 는 "자원이 비었다"를 알리고 끝난다 — 누군가 깨어나 다음을 올려야 했다.
+무인 운영에서 GPU가 노는 가장 흔한 원인은 잘못된 실험이 아니라 **끝난 줄 모름**이고,
+그 다음이 **깨어날 사람이 없음**이다. 이 프로세스는 큐가 있는 한 스스로 채운다.
+
+**하지 않는 것**: 커밋·푸시·PR·병합·삭제·코드 수정. 실험 실행과 기록까지다.
+판단이 필요한 사건(채택 발생 · 큐 소진 · 연속 무소득 · 가드 장기 위반)에서는 멈추고
+종료한다 — 그 종료가 곧 알림이다.
+
+사용:
+    python scripts/dispatch.py                     # experiment/queue.json 을 소비
+    python scripts/dispatch.py --keep-going        # 채택이 나와도 멈추지 않는다
+    python scripts/dispatch.py --dry-run           # 무엇을 실행할지만 찍는다
+
+큐 형식 (`experiment/queue.json`) — 한 항목이 라운드 하나다:
+
+    {"items": [{
+        "id": "E10",                       # 실행 태그이자 판정 키워드
+        "arms": ["w9:model.window_size=9", "rot10:data.aug_rotate_deg=10"],
+        "config": "configs.unit",          # 생략하면 configs.unit
+        "control": "U1_ref",               # 대조군 폴더명 조각 (다른 라운드 재사용 가능)
+        "watch": "val/cell/vertex_recall", # 가설이 지목한 지표
+        "status": "pending"                # pending|running|done|failed
+    }]}
+
+**4 GPU를 채우도록 arm을 4개 안팎으로 설계한다** — 항목은 순차 소비라 arm이 적으면 슬롯이 논다.
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import time
+from datetime import datetime
+from pathlib import Path
+
+PYTHON = ".venv/bin/python"
+QUEUE_DEFAULT = Path("experiment/queue.json")
+JOURNAL_DIR = Path("experiment")
+GPU_FREE_MIB = 2000  # 이보다 적게 쓰면 빈 슬롯으로 본다
+LOAD_LIMIT = 16.0  # 32코어의 절반 — 사람이 같은 CPU를 쓴다
+GUARD_PATIENCE = 30  # 가드 위반이 이만큼 연속되면 사람을 부른다
+BARREN_LIMIT = 2  # 연속 이 횟수만큼 채택 0이면 그 축은 소진됐다
+
+
+def main() -> None:
+    args = parse_args()
+    dispatcher = Dispatcher(args=args)
+    reason = dispatcher.serve()
+    print(f"\n=== dispatch 종료: {reason} ===")
+    print(f"시각 {datetime.now():%Y-%m-%d %H:%M:%S} · 큐 {args.queue}")
+    print("다음: 판정 결과를 확인하고 STATE.md를 갱신하라")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--queue", type=Path, default=QUEUE_DEFAULT)
+    parser.add_argument("--journal", type=Path, default=None, help="기본은 result_{mmdd}.md")
+    parser.add_argument("--interval", type=int, default=60, help="자원 확인 간격(초)")
+    parser.add_argument("--max-load", type=float, default=LOAD_LIMIT)
+    parser.add_argument("--keep-going", action="store_true", help="채택이 나와도 멈추지 않는다")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+class Dispatcher:
+    """큐 → 자원 대기 → 실행 → 판정 → 기록 을 반복한다. 판단이 필요하면 멈춘다."""
+
+    def __init__(self, *, args: argparse.Namespace) -> None:
+        self.args = args
+        self.queue = RoundQueue(path=args.queue)
+        self.watcher = SlotWatcher(max_load=args.max_load)
+        self.journal = args.journal or JOURNAL_DIR / f"result_{datetime.now():%m%d}.md"
+        self.barren = 0
+
+    def serve(self) -> str:
+        while True:
+            item = self.queue.next_pending()
+            if item is None:
+                return "큐 소진 — 새 가설이 필요하다"
+            stop = self.serve_one(item)
+            if stop:
+                return stop
+
+    def serve_one(self, item: dict) -> str:
+        """라운드 하나를 끝까지 본다. 멈춰야 할 사유가 생기면 그 문자열을 낸다."""
+        need = len(item["arms"])
+        if self.args.dry_run:  # 자원을 기다리지 않는다 — 무엇을 실행할지만 보여 주는 모드다
+            print(f"[dispatch] (dry-run) {item['id']} · arm {need}개 · {item['arms']}")
+            self.queue.mark(item, "dry-run")
+            return "dry-run 완료"
+        gpus = self.await_slots(need)
+        if gpus is None:
+            return f"가드 위반이 {GUARD_PATIENCE}회 연속 — 부하를 사람이 확인해야 한다"
+        print(f"[dispatch] {item['id']} 실행 · GPU {gpus} · arm {need}개")
+        self.queue.mark(item, "running")
+        code = self.launch(item, gpus)
+        self.queue.mark(item, "done" if code == 0 else f"failed({code})")
+        if code != 0:
+            return f"{item['id']} 실행 실패 (code={code})"
+        return self.settle(item)
+
+    def await_slots(self, need: int) -> str | None:
+        """필요한 만큼 GPU가 비고 부하가 상한 아래일 때까지 기다린다."""
+        violations = 0
+        while True:
+            free = self.watcher.free_gpus()
+            if len(free) >= need and self.watcher.load_ok():
+                return ",".join(free)
+            violations = violations + 1 if len(free) >= need else 0
+            if violations >= GUARD_PATIENCE:
+                return None
+            time.sleep(self.args.interval)
+
+    def launch(self, item: dict, gpus: str) -> int:
+        command = [
+            PYTHON,
+            "scripts/run_experiments.py",
+            "--round",
+            item["id"],
+            "--config",
+            item.get("config", "configs.unit"),
+            "--gpus",
+            gpus,
+            "--arms",
+            *item["arms"],
+        ]
+        return subprocess.run(command, check=False).returncode
+
+    def settle(self, item: dict) -> str:
+        """판정 → 일지 기록 → 정지 조건 확인. 이 셋은 한 묶음이다."""
+        verdict = self.judge(item)
+        adopted = verdict.get("adopted", [])
+        self.barren = 0 if adopted else self.barren + 1
+        self.queue.mark(item, "done", adopted=adopted)
+        if adopted and not self.args.keep_going:
+            return f"{item['id']} 채택 {len(adopted)}건 — 반영 여부를 사람이 정한다"
+        if self.barren >= BARREN_LIMIT:
+            return f"연속 {self.barren}라운드 채택 0 — 이 축은 소진됐다"
+        return ""
+
+    def judge(self, item: dict) -> dict:
+        out = Path(f"/tmp/judge_{item['id']}.json")
+        command = [
+            PYTHON,
+            "scripts/judge_round.py",
+            "--round",
+            item["id"],
+            "--control",
+            item.get("control", ""),
+            "--watch",
+            item.get("watch", "val/cell/vertex_recall"),
+            "--md",
+            str(self.journal),
+            "--json",
+            str(out),
+        ]
+        if subprocess.run(command, check=False).returncode != 0 or not out.exists():
+            print("[dispatch] 판정 실패 — 수치를 사람이 봐야 한다")
+            return {}
+        return json.loads(out.read_text(encoding="utf-8"))
+
+
+class RoundQueue:
+    """`queue.json` 하나가 대기열의 단일 출처다. 상태 전이를 그 파일에 즉시 쓴다."""
+
+    def __init__(self, *, path: Path) -> None:
+        self.path = path
+        self.data = json.loads(path.read_text(encoding="utf-8")) if path.exists() else {"items": []}
+
+    def next_pending(self) -> dict | None:
+        return next((item for item in self.data["items"] if item.get("status") == "pending"), None)
+
+    def mark(self, item: dict, status: str, adopted: list | None = None) -> None:
+        item["status"] = status
+        item["at"] = f"{datetime.now():%Y-%m-%d %H:%M}"
+        if adopted is not None:
+            item["adopted"] = adopted
+        self.path.write_text(
+            json.dumps(self.data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+        )
+
+
+class SlotWatcher:
+    """자원 관측만 한다 — 무엇을 할지는 Dispatcher가 정한다."""
+
+    def __init__(self, *, max_load: float) -> None:
+        self.max_load = max_load
+
+    def free_gpus(self) -> list[str]:
+        query = "--query-gpu=index,memory.used"
+        output = subprocess.run(
+            ["nvidia-smi", query, "--format=csv,noheader,nounits"],
+            capture_output=True,
+            text=True,
+            check=False,
+        ).stdout
+        rows = [line.split(",") for line in output.strip().splitlines() if line.strip()]
+        return [index.strip() for index, used in rows if int(used) < GPU_FREE_MIB]
+
+    def load_ok(self) -> bool:
+        return os.getloadavg()[0] <= self.max_load
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gate.py
+++ b/scripts/gate.py
@@ -1,0 +1,206 @@
+"""PR 전에 반드시 통과해야 하는 단일 관문 (improve-loop · 게이트).
+
+**문서에 적힌 규칙은 지켜지지 않고, 실행되는 스크립트는 지켜진다.** 실제로 "변형을 넣었으면
+GT 주입으로 회귀 확인부터" 라는 규칙이 SKILL에 있었지만 E06에서 건너뛰어졌다. 그래서
+검사를 파일 하나로 모았다.
+
+검사 목록과 하한값은 `gate_baseline.json` 에 있다 — **코드가 아니라 데이터다.** 새로운
+실패 양식을 만나면 코드를 고치지 않고 JSON에 항목을 하나 더한다.
+
+사용:
+    python scripts/gate.py                       # 전부
+    python scripts/gate.py --only pytest,ruff    # 빠른 것만
+    python scripts/gate.py --update              # 통과한 실측으로 하한을 래칫
+    python scripts/gate.py --workers 2           # 학습이 도는 중이면 낮춘다
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from configs.base import get_config
+from stella.builder import check_all
+from stella.config_io import load_config
+from stella.decode.sweep import build_cfg, evaluate_decode, list_files, read_meta, shape_of
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BASELINE_PATH = REPO_ROOT / "gate_baseline.json"
+CONFIG_DIR = REPO_ROOT / "configs"
+PYTHON_BIN = str(REPO_ROOT / ".venv/bin/python")
+CACHE_DIRNAME = "pred_cache"
+RATCHET_MARGIN = 0.10  # 실측이 하한을 이만큼 웃돌면 하한을 끌어올린다
+LOAD_LIMIT = 16.0  # 32코어의 절반. 학습 중에 게이트를 돌리면 부하가 31까지 뛴다(실측)
+STATUS_MARK = {True: "PASS", False: "FAIL", None: "SKIP"}
+
+
+def main() -> None:
+    args = parse_args()
+    refuse_if_busy(args)
+    spec = json.loads(BASELINE_PATH.read_text(encoding="utf-8"))
+    checks = [item for item in spec["checks"] if selected(item, args)]
+    results = [run_check(item, args) for item in checks]
+    print_report(results)
+    if args.update:
+        ratchet(spec, results)
+    sys.exit(exit_code(results, args.strict))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--only", default="", help="쉼표로 구분한 검사 id")
+    parser.add_argument("--skip", default="", help="쉼표로 구분한 검사 id")
+    parser.add_argument("--workers", type=int, default=4, help="디코딩 워커 (학습 중이면 낮춘다)")
+    parser.add_argument("--update", action="store_true", help="통과한 실측으로 하한 래칫")
+    parser.add_argument("--strict", action="store_true", help="SKIP도 실패로 센다")
+    parser.add_argument("--max-load", type=float, default=LOAD_LIMIT, help="이 부하 위면 거부")
+    parser.add_argument("--force", action="store_true", help="부하 가드를 무시하고 강행")
+    return parser.parse_args()
+
+
+def refuse_if_busy(args: argparse.Namespace) -> None:
+    """부하가 높으면 아예 시작하지 않는다.
+
+    실측: 학습 4 arm(부하 13)이 도는 중에 게이트를 돌렸더니 **부하가 31까지 뛰었다.**
+    pytest와 디코딩은 둘 다 CPU를 많이 쓴다. 게이트는 급한 일이 아니므로 자원이 빌 때
+    돌리는 것이 맞다 — 사람이 같은 CPU로 편집기를 쓴다.
+    """
+    load = os.getloadavg()[0]
+    if load <= args.max_load or args.force:
+        return
+    print(f"[gate] 부하 {load:.1f} > 상한 {args.max_load} — 시작하지 않는다.")
+    print("[gate] 자원이 빈 뒤 다시 돌리거나, 정말 지금 해야 하면 --force")
+    sys.exit(2)
+
+
+def selected(item: dict, args: argparse.Namespace) -> bool:
+    only = [s for s in args.only.split(",") if s]
+    skip = [s for s in args.skip.split(",") if s]
+    return (not only or item["id"] in only) and item["id"] not in skip
+
+
+def run_check(item: dict, args: argparse.Namespace) -> dict:
+    """검사 종류별 실행기를 부르고 소요 시간을 붙인다."""
+    runners = {
+        "command": run_command,
+        "configs": run_configs,
+        "install": run_install,
+        "decode": run_decode,
+    }
+    started = time.time()
+    print(f"[gate] {item['id']} ...", flush=True)
+    outcome = runners[item["kind"]](item, args)
+    return {**item, **outcome, "seconds": time.time() - started}
+
+
+def run_command(item: dict, args: argparse.Namespace) -> dict:
+    completed = subprocess.run(item["cmd"], capture_output=True, text=True)
+    tail = (completed.stdout + completed.stderr).strip().splitlines()[-3:]
+    return {"ok": completed.returncode == 0, "message": " / ".join(tail)[:160], "observed": {}}
+
+
+def run_configs(item: dict, args: argparse.Namespace) -> dict:
+    """모든 config 모듈을 실제로 해석해 본다 — path+name 오타를 학습 전에 잡는다."""
+    modules = sorted(
+        p.stem for p in CONFIG_DIR.glob("*.py") if p.stem not in ("schema", "__init__")
+    )
+    broken = []
+    for name in modules:
+        try:
+            check_all(load_config(f"configs.{name}", []))
+        except Exception as error:  # noqa: BLE001 — 어떤 예외든 게이트 실패로 본다
+            broken.append(f"{name}: {type(error).__name__} {error}")
+    return {
+        "ok": not broken,
+        "message": " / ".join(broken)[:160] or f"{len(modules)}개 해석",
+        "observed": {},
+    }
+
+
+def run_install(item: dict, args: argparse.Namespace) -> dict:
+    """editable 설치가 **이 저장소**를 가리키는지 본다.
+
+    `.venv`는 worktree와 공유된다. worktree에서 `uv sync`가 한 번 돌면 포인터가 그쪽으로
+    옮겨가고, 그 뒤 `python scripts/*.py`는 **남의 코드**로 돈다(`-m` 실행은 cwd가 우선해
+    멀쩡하므로 학습만 보면 눈치채지 못한다). 저장소 밖에서 import 해야 진짜로 잡힌다.
+    """
+    probe = "import stella, configs; print(stella.__file__); print(configs.__file__)"
+    completed = subprocess.run(
+        [PYTHON_BIN, "-c", probe], capture_output=True, text=True, cwd="/tmp", check=False
+    )
+    paths = [Path(line) for line in completed.stdout.strip().splitlines()]
+    stray = [str(p.parent) for p in paths if REPO_ROOT not in p.resolve().parents]
+    if completed.returncode != 0 or not paths:
+        return {"ok": False, "message": completed.stderr.strip()[-160:], "observed": {}}
+    message = f"딴 곳을 가리킨다: {stray}" if stray else f"{REPO_ROOT} 확인"
+    return {"ok": not stray, "message": message, "observed": {}}
+
+
+def run_decode(item: dict, args: argparse.Namespace) -> dict:
+    """캐시된 예측을 현재 기본 설정으로 디코딩해 지표가 하한 위인지 본다."""
+    cache = cache_root() / item["cache"]
+    if not cache.exists():
+        return {"ok": None, "message": f"캐시 없음: {cache}", "observed": {}}
+    scores = decode_scores(cache, item, args.workers)
+    failures = [
+        f"{key}={scores.get(key, float('nan')):.4f} < {bound['min']}"
+        for key, bound in item["bounds"].items()
+        if scores.get(key) is None or scores[key] < bound["min"]
+    ]
+    observed = {key: scores.get(key) for key in item["bounds"]}
+    detail = " ".join(f"{k}={v:.4f}" for k, v in observed.items() if v is not None)
+    return {"ok": not failures, "message": " / ".join(failures) or detail, "observed": observed}
+
+
+def decode_scores(cache: Path, item: dict, workers: int) -> dict:
+    meta = read_meta(cache)
+    files = list_files(cache, item.get("count", 0))
+    cfg = build_cfg(item.get("config", "configs.base"), item.get("set", []), meta)
+    return evaluate_decode(cfg, cfg.decode, files, shape_of(meta), workers)
+
+
+def cache_root() -> Path:
+    """예측 캐시는 로그 루트 옆에 둔다 (기계마다 경로가 달라 config에서 끌어온다)."""
+    return Path(get_config().train.output_root).parent / CACHE_DIRNAME
+
+
+def print_report(results: list[dict]) -> None:
+    print("\n[gate] 결과")
+    for row in results:
+        mark = STATUS_MARK[row["ok"]]
+        print(f"  {mark:<5} {row['id']:<16} {row['seconds']:6.1f}s  {row['message']}")
+    failed = [row["id"] for row in results if row["ok"] is False]
+    skipped = [row["id"] for row in results if row["ok"] is None]
+    print(
+        f"\n[gate] 실패 {len(failed)} · 건너뜀 {len(skipped)}" + (f" -> {failed}" if failed else "")
+    )
+
+
+def ratchet(spec: dict, results: list[dict]) -> None:
+    """좋아진 만큼 하한을 끌어올린다. 내리는 방향으로는 절대 자동으로 움직이지 않는다."""
+    lifted = []
+    for row in results:
+        if row["ok"] is not True or not row.get("observed"):
+            continue
+        target = next(item for item in spec["checks"] if item["id"] == row["id"])
+        for key, value in row["observed"].items():
+            floor = value * (1 - RATCHET_MARGIN)
+            if value is not None and floor > target["bounds"][key]["min"]:
+                lifted.append(f"{row['id']}.{key} {target['bounds'][key]['min']:.4f}->{floor:.4f}")
+                target["bounds"][key]["min"] = round(floor, 4)
+    BASELINE_PATH.write_text(
+        json.dumps(spec, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    print(f"[gate] 하한 갱신 {len(lifted)}건 " + (" · ".join(lifted) if lifted else "(변화 없음)"))
+
+
+def exit_code(results: list[dict], strict: bool) -> int:
+    bad = [row for row in results if row["ok"] is False or (strict and row["ok"] is None)]
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/judge_round.py
+++ b/scripts/judge_round.py
@@ -1,0 +1,191 @@
+"""라운드 하나를 판정한다 — SKILL 10절 판정 규칙을 그대로 코드로 옮긴 것.
+
+사람이 표를 눈으로 읽고 "채택/기각"을 말하면 세션마다 미묘하게 달라진다. 규칙이 이미
+기계적이므로(마지막 3에폭 평균 · 대조군 대비 ±10% · 지목 지표가 실제로 움직였는가)
+스크립트가 판정하고 사람은 해석만 한다.
+
+사용:
+    python scripts/judge_round.py --round E08 --control U1_ref
+    python scripts/judge_round.py --round E08 --control U1_ref --watch val/cell/vertex_recall \
+        --md experiment/result_0810.md --json /tmp/e08.json
+
+`--md` 는 마크다운 표를 그 파일에 덧붙인다 (일지에 바로 들어가는 형식).
+`--json` 은 dispatch가 정지 조건을 판단할 때 읽는다.
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+from configs.base import get_config
+from stella.eval.runlog import find_runs, relative_change, tail_mean
+
+PRIMARY = "val/inst/f1"
+DEFAULT_WATCH = "val/cell/vertex_recall"
+REPORT_KEYS = (
+    PRIMARY,
+    "val/inst/coverage",
+    "val/inst/frag",
+    "val/cell/heat_recall",
+    "val/cell/class_fg",
+    DEFAULT_WATCH,
+)
+SHORT_LABEL = {
+    PRIMARY: "f1",
+    "val/inst/coverage": "coverage",
+    "val/inst/frag": "frag",
+    "val/cell/heat_recall": "heatR",
+    "val/cell/class_fg": "clsFg",
+    DEFAULT_WATCH: "vtxRec",
+}
+ADOPT_MARGIN = 0.10  # 상대 +10% 이상 채택 (규칙 3)
+REJECT_MARGIN = -0.10  # 상대 −10% 이하 기각
+MOVE_MARGIN = 0.05  # 지목 지표가 "움직였다"의 하한 (규칙 4). 측정 잡음보다 크게 잡았다
+VERDICT_NOTE = {
+    "adopt": "채택",
+    "hold": "보류 — f1은 올랐으나 지목 지표가 안 움직였다. 재현 필요",
+    "neutral": "무효",
+    "reject": "기각",
+    "control": "대조군",
+}
+
+
+def main() -> None:
+    args = parse_args()
+    rows = collect_rows(args)
+    if not rows:
+        raise SystemExit(f"[judge] '{args.round}' 로 찾은 실행이 없다")
+    control = pick_control(rows, args.control)
+    judged = [judge_row(row, control, args.watch) for row in rows]
+    report = render(judged, args, control)
+    print(report)
+    emit(report, judged, args)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--round", required=True, help="실행 폴더명에 든 라운드 키워드 (예 E08)")
+    parser.add_argument("--control", default="", help="대조군 폴더명 조각. 없으면 라운드 안 첫 arm")
+    parser.add_argument("--watch", default=DEFAULT_WATCH, help="가설이 지목한 셀 지표")
+    parser.add_argument("--tail", type=int, default=3, help="마지막 N 에폭 평균")
+    parser.add_argument("--md", default="", help="마크다운을 덧붙일 파일")
+    parser.add_argument("--json", dest="json_out", default="", help="판정 결과 JSON 경로")
+    return parser.parse_args()
+
+
+def collect_rows(args: argparse.Namespace) -> list[dict]:
+    root = Path(get_config().train.output_root)
+    keys = tuple(dict.fromkeys([*REPORT_KEYS, args.watch]))
+    runs = find_runs(root, args.round)
+    if args.control:
+        runs += [r for r in find_runs(root, args.control) if r not in runs]
+    rows = [tail_mean(run, args.tail, keys) for run in runs]
+    return [row for row in rows if row]
+
+
+def pick_control(rows: list[dict], wanted: str) -> dict:
+    """대조군을 못 찾으면 판정 자체가 무의미하므로 조용히 넘어가지 않는다."""
+    if not wanted:
+        return rows[0]
+    matched = [row for row in rows if wanted in row["name"]]
+    if not matched:
+        raise SystemExit(f"[judge] 대조군 '{wanted}' 을(를) 찾지 못했다")
+    return matched[0]
+
+
+def judge_row(row: dict, control: dict, watch: str) -> dict:
+    primary_rel = relative_change(row.get(PRIMARY), control.get(PRIMARY))
+    watch_rel = relative_change(row.get(watch), control.get(watch))
+    tracked = control.get(watch) is not None  # 그 지표가 로그에 찍히기는 하는가
+    verdict = (
+        "control" if row["name"] == control["name"] else verdict_of(primary_rel, watch_rel, tracked)
+    )
+    return {**row, "primary_rel": primary_rel, "watch_rel": watch_rel, "verdict": verdict}
+
+
+def verdict_of(primary_rel: float | None, watch_rel: float | None, tracked: bool) -> str:
+    """규칙 3(±10%) 위에 규칙 4(지목 지표 확인)를 얹는다.
+
+    지목 지표가 **로그에 없는 것**과 **있는데 안 움직인 것**은 다르다. 전자는 규칙 4를
+    적용할 수 없다는 뜻이라 f1만으로 판정하고(리포트에 경고를 띄운다), 후자만 보류다.
+    """
+    if primary_rel is None:
+        return "neutral"
+    if primary_rel >= ADOPT_MARGIN:
+        if not tracked:
+            return "adopt"
+        return "adopt" if watch_rel is not None and abs(watch_rel) >= MOVE_MARGIN else "hold"
+    return "reject" if primary_rel <= REJECT_MARGIN else "neutral"
+
+
+def render(judged: list[dict], args: argparse.Namespace, control: dict) -> str:
+    columns = tuple(dict.fromkeys([*REPORT_KEYS, args.watch]))
+    lines = [
+        f"### {args.round} 자동 판정 (마지막 {args.tail}에폭 평균, 대조군 `{control['name']}`)",
+        "",
+        header_line(columns),
+        divider_line(columns),
+    ]
+    lines += [body_line(row, columns) for row in judged]
+    lines += ["", summary_line(judged)]
+    if control.get(args.watch) is None:
+        lines += [
+            "",
+            f"> 경고: 지목 지표 `{args.watch}` 가 로그에 없다 — 규칙 4를 적용하지 못했다."
+            " f1만으로 판정했으므로 재현 확인이 필요하다.",
+        ]
+    return "\n".join(lines)
+
+
+def header_line(columns: tuple[str, ...]) -> str:
+    labels = " | ".join(SHORT_LABEL.get(key, key.split("/")[-1]) for key in columns)
+    return f"| arm | ep | {labels} | f1 Δ% | 지목 Δ% | 판정 |"
+
+
+def divider_line(columns: tuple[str, ...]) -> str:
+    return "| --- | --- | " + " | ".join(["---"] * len(columns)) + " | --- | --- | --- |"
+
+
+def body_line(row: dict, columns: tuple[str, ...]) -> str:
+    values = " | ".join(fmt_value(row.get(key)) for key in columns)
+    verdict = VERDICT_NOTE[row["verdict"]]
+    return (
+        f"| {row['name'][-30:]} | {row['epochs']} | {values} | "
+        f"{fmt_percent(row['primary_rel'])} | {fmt_percent(row['watch_rel'])} | **{verdict}** |"
+    )
+
+
+def fmt_value(value) -> str:
+    return "-" if value is None else f"{value:.4f}"
+
+
+def fmt_percent(value) -> str:
+    return "-" if value is None else f"{value * 100:+.1f}"
+
+
+def summary_line(judged: list[dict]) -> str:
+    adopted = [row["name"] for row in judged if row["verdict"] == "adopt"]
+    held = [row["name"] for row in judged if row["verdict"] == "hold"]
+    if adopted:
+        return f"**채택 {len(adopted)}건**: {', '.join(adopted)}" + (
+            f" · 보류 {len(held)}건" if held else ""
+        )
+    return "**채택 0건** — 이 축은 소진됐을 수 있다 (연속 2라운드면 정지 조건)"
+
+
+def emit(report: str, judged: list[dict], args: argparse.Namespace) -> None:
+    if args.md:
+        with open(args.md, "a", encoding="utf-8") as handle:
+            handle.write("\n\n" + report + "\n")
+    if args.json_out:
+        payload = {
+            "round": args.round,
+            "watch": args.watch,
+            "adopted": [row["name"] for row in judged if row["verdict"] == "adopt"],
+            "rows": [{k: v for k, v in row.items() if k != "path"} for row in judged],
+        }
+        Path(args.json_out).write_text(json.dumps(payload, indent=2, ensure_ascii=False), "utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/summarize_runs.py
+++ b/scripts/summarize_runs.py
@@ -9,10 +9,10 @@
 """
 
 import argparse
-import csv
 from pathlib import Path
 
 from configs.base import get_config
+from stella.eval.runlog import latest_runs, tail_mean
 
 INSTANCE_COLUMNS = (
     ("val/inst/f1", "f1"),
@@ -53,8 +53,9 @@ DIAGNOSTIC_COLUMNS = (
 
 def main() -> None:
     args = parse_args()
-    runs = [Path(p) for p in args.runs] if args.runs else latest_runs(args.last)
-    rows = [summarize(run, args.tail) for run in runs]
+    root = Path(get_config().train.output_root)
+    runs = [Path(p) for p in args.runs] if args.runs else latest_runs(root, args.last)
+    rows = [tail_mean(run, args.tail, all_keys()) for run in runs]
     rows = [row for row in rows if row]
     print_block("인스턴스 지표", rows, INSTANCE_COLUMNS)
     print_block("셀·디코더 진단", rows, DIAGNOSTIC_COLUMNS)
@@ -68,39 +69,8 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def latest_runs(count: int) -> list[Path]:
-    root = Path(get_config().train.output_root)
-    runs = sorted((p for p in root.iterdir() if (p / "metrics.csv").exists()), key=lambda p: p.name)
-    return runs[-count:]
-
-
-def summarize(run: Path, tail: int) -> dict | None:
-    merged = merge_by_epoch(run / "metrics.csv")
-    epochs = [e for e in sorted(merged) if "val/inst/f1" in merged[e]]
-    if not epochs:
-        return None
-    window = epochs[-tail:]
-    values = {key: _mean(merged, window, key) for key in _all_keys()}
-    return {"name": run.name, "epochs": len(epochs), **values}
-
-
-def merge_by_epoch(path: Path) -> dict[int, dict]:
-    """Lightning은 train/val 스칼라를 다른 행에 쓴다 — 에폭 기준으로 합친다."""
-    merged: dict[int, dict] = {}
-    with open(path, encoding="utf-8") as handle:
-        for row in csv.DictReader(handle):
-            target = merged.setdefault(int(row["epoch"]), {})
-            target.update({k: v for k, v in row.items() if v not in ("", None)})
-    return merged
-
-
-def _all_keys() -> tuple[str, ...]:
+def all_keys() -> tuple[str, ...]:
     return tuple(key for key, _ in INSTANCE_COLUMNS + DIAGNOSTIC_COLUMNS)
-
-
-def _mean(merged: dict, epochs: list[int], key: str) -> float | None:
-    values = [float(merged[e][key]) for e in epochs if key in merged[e]]
-    return sum(values) / len(values) if values else None
 
 
 def print_block(title: str, rows: list[dict], columns: tuple) -> None:

--- a/stella/eval/runlog.py
+++ b/stella/eval/runlog.py
@@ -1,0 +1,60 @@
+"""학습 실행 폴더의 `metrics.csv`를 읽어 에폭 평균 지표를 낸다 (improve-loop · 관측·판정 공용).
+
+`scripts/summarize_runs.py`(사람이 보는 표)와 `scripts/judge_round.py`(자동 판정)가 같은
+함수를 쓴다. **읽는 곳이 하나여야 판정이 사람 눈과 스크립트에서 갈라지지 않는다.**
+
+마지막 에폭 하나는 크게 튀므로 비교는 항상 **마지막 N 에폭 평균**으로 한다 (판정 규칙 2).
+"""
+
+import csv
+from pathlib import Path
+
+EPOCH_KEY = "epoch"
+PRESENCE_KEY = "val/inst/f1"  # 이 값이 있어야 "평가가 끝난 에폭"이다
+
+
+def latest_runs(root: Path, count: int) -> list[Path]:
+    """로그 루트에서 최근 실행 N개. 폴더명이 `YYMMDD_HHMMSS_...` 라 이름순 = 시간순."""
+    return sorted(finished_runs(root), key=lambda p: p.name)[-count:]
+
+
+def find_runs(root: Path, keyword: str) -> list[Path]:
+    """폴더명에 keyword가 든 실행 전부 (라운드 태그로 arm을 모을 때 쓴다)."""
+    return sorted((p for p in finished_runs(root) if keyword in p.name), key=lambda p: p.name)
+
+
+def finished_runs(root: Path):
+    return (p for p in root.iterdir() if (p / "metrics.csv").exists())
+
+
+def tail_mean(run: Path, tail: int, keys: tuple[str, ...]) -> dict | None:
+    """마지막 `tail` 에폭의 평균. 평가된 에폭이 하나도 없으면 None."""
+    merged = merge_by_epoch(run / "metrics.csv")
+    epochs = [e for e in sorted(merged) if PRESENCE_KEY in merged[e]]
+    if not epochs:
+        return None
+    window = epochs[-tail:]
+    values = {key: mean_of(merged, window, key) for key in keys}
+    return {"name": run.name, "path": str(run), "epochs": len(epochs), **values}
+
+
+def merge_by_epoch(path: Path) -> dict[int, dict]:
+    """Lightning은 train/val 스칼라를 다른 행에 쓴다 — 에폭 기준으로 합친다."""
+    merged: dict[int, dict] = {}
+    with open(path, encoding="utf-8") as handle:
+        for row in csv.DictReader(handle):
+            target = merged.setdefault(int(row[EPOCH_KEY]), {})
+            target.update({k: v for k, v in row.items() if v not in ("", None)})
+    return merged
+
+
+def mean_of(merged: dict, epochs: list[int], key: str) -> float | None:
+    values = [float(merged[e][key]) for e in epochs if key in merged[e]]
+    return sum(values) / len(values) if values else None
+
+
+def relative_change(value: float | None, base: float | None) -> float | None:
+    """대조군 대비 상대 변화. 대조군이 0이거나 값이 없으면 None."""
+    if value is None or base is None or base == 0:
+        return None
+    return (value - base) / abs(base)


### PR DESCRIPTION
## 무엇을

무인 개선 루프에서 사람 손에 걸려 있던 세 지점을 스크립트로 옮긴다. **문서에 적힌 규칙은
지켜지지 않고, 실행되는 스크립트는 지켜진다** — 실제로 "변형을 넣었으면 GT 주입으로 회귀
확인부터"라는 규약이 E06에서 그대로 건너뛰어졌다.

| 추가 | 역할 |
| --- | --- |
| `scripts/gate.py` + `gate_baseline.json` | PR 전 단일 관문. 검사 목록·하한을 **데이터**로 관리 |
| `scripts/judge_round.py` | SKILL 10절 판정 규칙을 코드로 |
| `scripts/dispatch.py` | 감시자 → 디스패처. 큐를 스스로 소비 |
| `stella/eval/runlog.py` | `metrics.csv` 읽기 단일 출처 |

## 게이트는 고정 목록이 아니다

검사 정의를 JSON에 두어 **새 실패 양식을 만날 때마다 코드 수정 없이 항목을 더한다.**
각 항목에 `why`(어떤 사고를 막나)와 `since`(계기가 된 실험)를 남긴다.
하한은 `--update`로 실측의 90%까지 **래칫**되고, 내리는 방향으로는 자동으로 움직이지 않는다.

## 만들자마자 실제로 하나를 잡았다

`editable` 설치가 **4커밋 전 worktree**(`a79ec7c`)를 가리키고 있었다. 그래서
`python scripts/*.py` 실행이 전부 남의 코드로 돌고 있었다 — `python -m ...`(학습)은
cwd가 우선해 멀쩡했으므로 **학습 지표만 보면 끝까지 눈치챌 수 없는 종류**다.
포인터를 되돌리고 `install` 검사를 게이트에 추가했다.

영향 확인: 해당 커밋과 현재 사이의 `stella/decode/` 차이는 **주석뿐**이라 D 트랙(E04·E06)
결과는 유효하다. 실질 로직 차이는 `cellstat.py`의 `vertex_recall` 추가 하나이고,
학습은 로컬 코드를 썼다(E05 로그에 해당 지표가 찍힌 것이 증거).

## 검증

- `judge_round.py` 를 E05 실행 4개에 돌려 **기존 수동 판정과 수치·결론이 일치**함을 확인
  (0.1737 / 0.1770 / 0.1397 / 0.0653 → 대조군 / 무효 / 기각 / 기각).
- `gate.py` — `pytest`(72 passed) · `ruff` · `format` · `configs`(6개 해석) · `install` 통과.
- `dispatch.py --dry-run` — 큐 소비·상태 전이 확인.
- **미검증**: `ceiling_gt` · `model_regress`(디코딩 검사)는 E08 학습이 GPU·CPU를 쓰는 중이라
  아직 실측하지 않았다. 학습 종료 후 돌려 하한을 확정한다.

## 부작용 방지

- 게이트가 부하 16 초과 시 **스스로 거부**한다 (학습에 얹었더니 부하 31까지 뛴 실측).
- ruff `extend-exclude = ["docs", ".claude"]` — 포매터가 설계 문서의 코드 예시를 펴지 않게.

🤖 Generated with [Claude Code](https://claude.com/claude-code)