### PR TITLE
코어 예약이 실제로는 안 걸려 있었다 — 모든 스레드를 묶는다

### DIFF
--- a/stella/runtime/cpu.py
+++ b/stella/runtime/cpu.py
@@ -41,11 +41,11 @@ class CpuBudget(Buildable):
     def apply(self) -> dict:
         """예산을 이 프로세스에 건다. 반환값은 로그·기록용 요약이다."""
         core_ids = self.core_ids()
-        if core_ids:
-            os.sched_setaffinity(0, core_ids)
+        pinned = pin_all_threads(core_ids) if core_ids else 0
         self._apply_threads()
         return {
             "cores": len(core_ids) if core_ids else os.cpu_count(),
+            "pinned_threads": pinned,
             "torch_threads": self.torch_threads,
             "interop_threads": self.interop_threads,
             "expected_threads": self.expected_threads(),
@@ -71,6 +71,27 @@ class CpuBudget(Buildable):
     def expected_threads(self, processes: int = 1) -> int:
         """프로세스 수를 주면 예상 러너블 스레드 수를 낸다 — 부하를 미리 가늠하는 용도."""
         return processes * max(self.torch_threads, 1)
+
+
+def pin_all_threads(core_ids: list[int]) -> int:
+    """이 프로세스의 **모든 스레드**를 주어진 코어에 묶고, 묶은 개수를 낸다.
+
+    `sched_setaffinity(0, ...)`는 **부르는 스레드 하나만** 바꾼다. 프로세스 단위로 걸린다고
+    착각하기 쉬운데, torch는 import 시점에 이미 스레드를 여럿 띄워 두므로 그것들이 그대로
+    전 코어에 남는다(실측: 34개 중 31개가 안 묶였다). 그래서 `/proc/self/task`를 훑어
+    TID마다 건다.
+
+    지금 있는 스레드를 전부 묶으면 **이후에 생기는 스레드는 자동으로 따라온다** —
+    새 스레드는 자기를 만든 스레드의 친화도를 물려받기 때문이다.
+    """
+    pinned = 0
+    for entry in os.listdir("/proc/self/task"):
+        try:
+            os.sched_setaffinity(int(entry), core_ids)
+            pinned += 1
+        except (OSError, ValueError):  # 그 사이에 끝난 스레드는 넘어간다
+            continue
+    return pinned
 
 
 def _set_interop_threads(count: int) -> None:

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -52,3 +52,37 @@ def test_budget_builds_from_config():
     budget = build_instance(cfg.cpu, cfg)
     assert isinstance(budget, CpuBudget)
     assert budget.torch_threads == cfg.cpu.torch_threads
+
+
+def test_apply_pins_every_thread_not_just_the_caller():
+    """`sched_setaffinity(0, ...)`는 **부르는 스레드 하나만** 바꾼다.
+
+    프로세스 단위로 걸린다고 착각하면, torch가 import 시점에 띄워 둔 스레드들이 그대로
+    전 코어에 남아 예약이 무너진다(실측: 34개 중 31개가 안 묶였다). 그때 사람이 쓰는
+    코어까지 학습 스레드가 올라가 대화형 반응이 느려진다. 이 테스트가 그 재발을 막는다.
+    """
+    import threading
+
+    total = os.cpu_count() or 1
+    if total < 2:
+        return  # 코어가 하나면 예약할 것이 없다
+    started = threading.Event()
+    keep = threading.Event()
+
+    def idle():
+        started.set()
+        keep.wait(5)
+
+    worker = threading.Thread(target=idle, daemon=True)
+    worker.start()
+    started.wait(5)
+    try:
+        budget = CpuBudget(torch_threads=1, interop_threads=1, cores="", reserved_cores=1)
+        expected = set(budget.core_ids())
+        budget.apply()
+        seen = {frozenset(os.sched_getaffinity(int(tid))) for tid in os.listdir("/proc/self/task")}
+        assert seen == {frozenset(expected)}, f"묶이지 않은 스레드가 있다: {seen}"
+    finally:
+        keep.set()
+        worker.join(5)
+        os.sched_setaffinity(0, range(total))  # 테스트가 프로세스를 좁혀 둔 채 끝나지 않게


### PR DESCRIPTION
PR #11의 후속 수정. **예약을 넣었는데 실제로는 격리가 전혀 되지 않고 있었다.**

## 증상

코어 예약(PR #11) 병합 후에도 사용자가 **"마우스 반응이 느리고 CPU가 대부분 쓰이는 것 같다"** 고
보고했다. "예전에 띄운 실험 때문이냐"는 질문이었는데, 재 보니 그게 아니라 **예약 자체가
작동하지 않고 있었다.**

| | |
| --- | --- |
| 프로세스 주 스레드 | `0-21` ✅ |
| **나머지 스레드 (프로세스당 ~30개)** | **`0-31`** ❌ |
| 학습 스레드 총합 | **1076개 — 전부 사용자 코어를 쓰고 있었다** |

## 원인

**`os.sched_setaffinity(0, ...)`는 부르는 스레드 하나만 바꾼다.** 프로세스 단위로 걸린다고
착각하기 쉽지만 아니다. 게다가 **torch는 import 시점에 이미 스레드를 여럿 띄우므로**,
`apply()`가 나중에 불려도 그 스레드들은 그대로 전 코어에 남는다.

실측 — 수정 전 `apply()` 직후:

```
스레드 친화도 분포: {'0-21': 3, '0-31': 31}
```

같은 함정이 CLI에도 있다: `taskset -cp`는 주 스레드만, 모든 스레드는 **`taskset -a -cp`**.

## 수정

`pin_all_threads()` — `/proc/self/task`를 훑어 **TID마다** 건다.

**지금 있는 스레드를 전부 묶으면 이후에 생기는 스레드는 자동으로 따라온다** — 새 스레드는
자기를 만든 스레드의 친화도를 물려받기 때문이다. 그래서 한 번만 걸면 된다.

실측 — 수정 후 (apply 이후에 torch 연산으로 스레드 풀을 강제 생성):

```
apply 요약: {'cores': 22, 'pinned_threads': 22, 'torch_threads': 2, ...}
스레드 친화도 분포: {'0-21': 24}
```

## 회귀 테스트

`apply()` **전에** 스레드를 하나 띄워 두고, `apply()` 후 **모든 TID**의 친화도 집합이 하나인지
검사한다. **옛 구현으로 같은 검사를 돌려 실제로 실패하는 것까지 확인**했다 — 통과만 보고
가드가 동작한다고 믿지 않기 위해서다.

## 코어별 사용률 (수정 후 실측)

```
코어  0-21 (학습):  64 38 43 36 47 73 94 73 65 68 82 47 57 87 58 55 53 48 43 99 78 33   평균 61%
코어 22-31 (사용자): 16 10 34 25 16 42 26 11 20 30                                      평균 23%
```

사용자 코어의 23%는 원격 데스크톱·에디터 등 **사용자 본인 작업**이다 — 학습 스레드는 이제
그 코어에 접근 자체가 불가능하다.

## 게이트 — 6개 전부 통과

| 검사 | 결과 |
| --- | --- |
| pytest / ruff / format / configs | PASS |
| `ceiling_gt` | PASS f1 **0.9720** |
| `model_regress` | PASS f1 **0.1016** |

decode 검사를 함께 돌린 이유: `eval_decode.py`가 진입 시 `apply()`를 부르므로 이 변경의
영향권 안에 있다.

## 교훈

**자원 격리는 걸었다고 믿지 말고 관측해서 확인한다.** "프로세스에 걸었다"와 "모든 스레드에
걸렸다"는 다르고, 이 차이가 사용자 체감의 전부였다.