### PR TITLE
E12 — 전경/배경 판정을 12지 CE에서 떼어 이진 헤드로

### DIFF
--- a/configs/schema.py
+++ b/configs/schema.py
@@ -84,6 +84,10 @@ class ModelConfig(ModuleConfig):
     # 활성 메모리가 w^2 에 비례하고 실제 연결은 디코더 탐색 반경 2셀 안에서 일어난다.
     # 실측(n_max 6000, bs 1): 9 -> 7 에서 peak 12.09 -> 9.72 GiB, step 455 -> 291 ms (7.6절).
     window_size: int = 7  # w
+    # 디코더는 `argmax != 0`(전경이냐)만 쓰는데 12지 CE가 그 판정과 종류 분류를 겸한다.
+    # 손실의 대부분은 정점을 살리는 종류 혼동이 먹고, 치명적인 "배경이라 부름"과 섞여 경쟁한다.
+    # True면 전경 로짓 1채널을 따로 둔다 (E12). False면 파라미터가 아예 생기지 않는다.
+    fg_head: bool = False
     ffn_dim: int = 1024
     dropout: float = 0.0
     grad_checkpoint: bool = True  # 윈도우 층만 재계산 (활성의 대부분이 거기 있다, 7.6절)
@@ -128,6 +132,9 @@ class SelfSlotLossConfig(ModuleConfig):
     # 희소 클래스 3종(bus_only_lane·safety_zone·bicycle_lane)이 200장에서 한 번도 예측되지
     # 않았다 (E07). 전경 가중을 인스턴스 빈도의 -power 승으로 준다. 0.0 = 가중 없음 (E09)
     class_freq_power: float = 0.0
+    # 전경/배경 이진 BCE (E12). `model.fg_head=True`와 함께 쓴다. 0.0 = 항 자체를 계산하지 않는다.
+    w_fg: float = 0.0
+    fg_pos_weight: float = 1.0  # 선택 셀의 ~70%가 배경이라 양성 쪽을 들 수 있게 열어 둔다
 
 
 @dataclass(kw_only=True)
@@ -171,6 +178,9 @@ class DecodeConfig(ModuleConfig):
     opp_thresh: float = 0.7  # 마주봄 하한 — -(c . n) >= 이 값 (10.3절)
     w_opp: float = 1.0  # 후보 비용에서 마주봄 항의 비중
     min_class_prob: float = 0.1  # 확장 게이트 — 후보의 사슬 클래스 softmax 확률 하한 (10.3절)
+    # 정점의 배경 필터. 음수면 기존 방식(`argmax != 0`),
+    # 0 이상이면 전경 로짓 확률의 하한을 쓴다 (E12).
+    fg_thresh: float = -1.0
     purity_thresh: float = 0.6  # 사슬 순도 하한 — argmax 클래스 일치 비율. 이하면 사슬 폐기
     end_extend: float = 1.0  # 끝 셀에서 끝방향 슬롯으로 연장하는 길이(셀) — 10.3절 끝 연장
     min_points: int = 2  # 이보다 짧은 폴리라인은 버린다 (연장점 포함)

--- a/stella/decode/cache.py
+++ b/stella/decode/cache.py
@@ -54,6 +54,7 @@ def _to_dense(sparse: dict, shape: dict) -> ModelOutput:
         class_logit=torch.zeros((side, side, classes)),
         self_coord=torch.zeros((side, side, 2)),
         end_logit=torch.zeros((side, side)),
+        fg_logit=torch.zeros((side, side)),
         exist_logit=torch.zeros((side, side, slots)),
         conn_dir=torch.zeros((side, side, slots, 2)),
     )

--- a/stella/decode/graph.py
+++ b/stella/decode/graph.py
@@ -62,6 +62,7 @@ class ChainDecoder:
         merge_align: float,
         align_mode: str,
         perp_thresh: float,
+        fg_thresh: float,
     ):
         if align_mode not in ALIGN_MODES:
             raise ValueError(f"align_mode 는 {ALIGN_MODES} 중 하나여야 한다: {align_mode}")
@@ -85,6 +86,7 @@ class ChainDecoder:
             radius=radius,
             seed_mode=seed_mode,
             end_thresh=end_thresh,
+            fg_thresh=fg_thresh,
         )
         self.merger = ChainMerger(gap=merge_gap, align_cos=merge_align)
         self.stats = ChainStats()

--- a/stella/decode/vertices.py
+++ b/stella/decode/vertices.py
@@ -22,6 +22,7 @@ class VertexExtractor:
         radius: int,
         seed_mode: str,
         end_thresh: float,
+        fg_thresh: float,
     ):
         if seed_mode not in SEED_MODES:
             raise ValueError(f"seed_mode 는 {SEED_MODES} 중 하나여야 한다: {seed_mode}")
@@ -30,13 +31,14 @@ class VertexExtractor:
         self.radius = radius
         self.seed_mode = seed_mode
         self.end_thresh = end_thresh
+        self.fg_thresh = fg_thresh
 
     def __call__(self, output) -> dict:
         """학습 dilation 없이 노드 셀을 고르고 정점 속성을 모은다."""
         arrays = {k: _to_numpy(v) for k, v in vars(output).items()}
         heat = _sigmoid(arrays["heatmap_logit"])
         label = arrays["class_logit"].argmax(axis=-1)
-        keep = arrays["node_mask"] & (heat > self.heatmap_thresh) & (label > 0)
+        keep = arrays["node_mask"] & (heat > self.heatmap_thresh) & self._foreground(arrays, label)
         cells = np.argwhere(keep)
         rows, cols = cells[:, 0], cells[:, 1]
         coord = arrays["self_coord"][rows, cols]
@@ -52,6 +54,12 @@ class VertexExtractor:
             "dir": arrays["conn_dir"][rows, cols],
             "neighbors": self.neighbor_table(cells, self.radius),
         }
+
+    def _foreground(self, arrays: dict, label: np.ndarray) -> np.ndarray:
+        """전경 판정. `fg_thresh < 0`이면 기존 `argmax != 0`, 아니면 이진 로짓 (E12)."""
+        if self.fg_thresh < 0.0:
+            return label > 0
+        return _sigmoid(arrays["fg_logit"]) > self.fg_thresh
 
     def neighbor_table(self, cells: np.ndarray, radius: int) -> np.ndarray:
         """각 정점의 체비셰프 반경 안 정점 인덱스 (V, (2r+1)^2). 빈 칸은 -1."""

--- a/stella/eval/cellstat.py
+++ b/stella/eval/cellstat.py
@@ -28,6 +28,7 @@ COUNT_STATES = (
     "node_count",
     "node_on_gt",
     "class_hit",
+    "fg_hit",
     "class_count",
     "class_fg_hit",
     "bg_hit",
@@ -121,6 +122,7 @@ class CellDiagnostics(Metric):
         self.class_count += both.sum()
         self.class_hit += (predicted[both] == targets["class_map"][both]).sum()
         self.class_fg_hit += (predicted[both] > 0).sum()
+        self.fg_hit += (output.fg_logit[both] > 0.0).sum()  # 이진 헤드 기준 (E12)
         self.bg_count += false_positive.sum()
         self.bg_hit += (predicted[false_positive] == 0).sum()
 
@@ -186,6 +188,8 @@ class CellDiagnostics(Metric):
             "node_per_img": _ratio(self.node_count, self.samples),
             "class_acc": _ratio(self.class_hit, self.class_count),
             "class_fg": _ratio(self.class_fg_hit, self.class_count),
+            # 이진 전경 헤드가 같은 셀을 전경이라 부르는 비율 (E12). 헤드가 꺼져 있으면 0이다.
+            "fg_acc": _ratio(self.fg_hit, self.class_count),
             # 분모가 **전체 GT 셀**이라 선택 수가 달라도 비교할 수 있다 (아래 주석).
             "class_recall": _ratio(self.class_hit, self.heat_gt),
             "vertex_recall": _ratio(self.class_fg_hit, self.heat_gt),

--- a/stella/loss/self_slot.py
+++ b/stella/loss/self_slot.py
@@ -29,6 +29,8 @@ class SelfSlotLoss(LossModule):
         class_bg_weight: float,
         class_freq_power: float,
         num_classes: int,
+        w_fg: float,
+        fg_pos_weight: float,
     ):
         super().__init__()
         self.w_class = w_class
@@ -36,6 +38,8 @@ class SelfSlotLoss(LossModule):
         self.w_end = w_end
         self.end_pos_weight = end_pos_weight
         self.class_bg_weight = class_bg_weight
+        self.w_fg = w_fg
+        self.fg_pos_weight = fg_pos_weight
         self.register_buffer(
             "class_weight", self._build_class_weight(num_classes, class_freq_power, class_bg_weight)
         )
@@ -61,8 +65,38 @@ class SelfSlotLoss(LossModule):
         class_loss = self._class_loss(output, targets)
         coord_loss = self._coord_loss(output, targets, positive)
         end_loss = self._end_loss(output, targets, positive)
-        total = self.w_class * class_loss + self.w_coord * coord_loss + self.w_end * end_loss
-        return {"class": class_loss, "coord": coord_loss, "end": end_loss, "total": total}
+        fg_loss = self._fg_loss(output, targets)
+        total = (
+            self.w_class * class_loss
+            + self.w_coord * coord_loss
+            + self.w_end * end_loss
+            + self.w_fg * fg_loss
+        )
+        return {
+            "class": class_loss,
+            "coord": coord_loss,
+            "end": end_loss,
+            "fg": fg_loss,
+            "total": total,
+        }
+
+    def _fg_loss(self, output, targets: dict) -> torch.Tensor:
+        """전경/배경 이진 감독 (E12).
+
+        디코더가 정점을 만들 때 실제로 묻는 것은 **"전경이냐"** 하나뿐인데(10.2절 배경 필터),
+        12지 CE는 그 판정과 종류 분류를 겸한다. 손실의 대부분은 흔한 클래스끼리의 혼동이
+        먹고, 그 오류는 정점을 살리므로 디코더에 덜 치명적이다. 즉 **치명적인 오류와 덜
+        치명적인 오류가 한 항에서 경쟁**한다. 이 항이 앞의 판정만 따로 감독한다.
+
+        `w_fg = 0`이면 계산 자체를 건너뛴다 — 기존 실행과 값이 그대로여야 비교가 선다.
+        """
+        selected = output.node_mask
+        if self.w_fg == 0.0 or not bool(selected.any()):
+            return output.fg_logit.sum() * 0.0
+        predicted = output.fg_logit[selected].float()
+        target = (targets["class_map"][selected] > 0).float()
+        weight = predicted.new_tensor(self.fg_pos_weight)
+        return F.binary_cross_entropy_with_logits(predicted, target, pos_weight=weight)
 
     def _class_loss(self, output, targets: dict) -> torch.Tensor:
         """선택된 전 셀 — class_map이 배경 0이라 거짓 양성 셀의 라벨이 그대로 0이 된다.

--- a/stella/model/heads.py
+++ b/stella/model/heads.py
@@ -21,19 +21,30 @@ CONN_OUTPUT_DIM = 3  # exist 1 + dir 2
 class SelfHead(nn.Module):
     """self 슬롯 -> 클래스 로짓 + 셀 내 좌표 + 끝 로짓 (end_map 직접 감독, 8.2절)."""
 
-    def __init__(self, *, d_model: int, num_classes: int, hidden_layers: int = 1):
+    def __init__(self, *, d_model: int, num_classes: int, fg_head: bool, hidden_layers: int = 1):
         super().__init__()
         self.class_mlp = build_mlp(d_model, num_classes, hidden_layers)
         self.coord_mlp = build_mlp(d_model, 2, hidden_layers)
         self.end_mlp = build_mlp(d_model, 1, hidden_layers)
+        # 끄면 파라미터가 아예 생기지 않는다 — 기존 실행과 초기화까지 동일해야 비교가 선다.
+        self.fg_mlp = build_mlp(d_model, 1, hidden_layers) if fg_head else None
 
-    def forward(self, tokens: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        """tokens: (N, D) -> class_logit (N, C), self_coord (N, 2) in [0, 1], end_logit (N,)."""
+    def forward(self, tokens: torch.Tensor) -> tuple[torch.Tensor, ...]:
+        """tokens: (N, D) -> class_logit (N, C), self_coord (N, 2), end_logit (N,), fg_logit (N,).
+
+        `fg_logit`은 헤드를 끄면 0이다 — 계약을 한 가지로 유지해 하류가 분기하지 않게 한다.
+        """
         return (
             self.class_mlp(tokens),
             self.coord_mlp(tokens).sigmoid(),
             self.end_mlp(tokens).squeeze(-1),
+            self._foreground(tokens),
         )
+
+    def _foreground(self, tokens: torch.Tensor) -> torch.Tensor:
+        if self.fg_mlp is None:
+            return tokens.new_zeros(tokens.shape[0])
+        return self.fg_mlp(tokens).squeeze(-1)
 
 
 class ConnHead(nn.Module):

--- a/stella/model/inject.py
+++ b/stella/model/inject.py
@@ -23,6 +23,7 @@ def gt_model_output(targets: dict, num_classes: int, num_slots: int) -> ModelOut
         class_logit=torch.zeros((*shape, num_classes)),
         self_coord=torch.zeros((*shape, 2)),
         end_logit=torch.where(targets["end_map"] > 0, HIGH_LOGIT, -HIGH_LOGIT),
+        fg_logit=torch.where(positive, HIGH_LOGIT, -HIGH_LOGIT),
         exist_logit=torch.full((*shape, num_slots), -HIGH_LOGIT),
         conn_dir=torch.zeros((*shape, num_slots, 2)),
     )

--- a/stella/model/stella.py
+++ b/stella/model/stella.py
@@ -28,6 +28,9 @@ class ModelOutput:
     class_logit: torch.Tensor  # (B, L, L, C)
     self_coord: torch.Tensor  # (B, L, L, 2) in [0, 1], 원점 = 셀 좌상단
     end_logit: torch.Tensor  # (B, L, L) — "이 셀이 사슬의 끝", end_map 직접 감독 (9차 개정)
+    # (B, L, L) — "이 셀이 전경이냐"만 보는 이진 로짓.
+    # `model.fg_head`가 꺼져 있으면 전부 0이다 (E12).
+    fg_logit: torch.Tensor
     exist_logit: torch.Tensor  # (B, L, L, R)
     conn_dir: torch.Tensor  # (B, L, L, R, 2) 단위벡터, 원점 = 자기 노드 점 (6.1절)
 
@@ -54,6 +57,7 @@ class StellaModel(nn.Module):
         dropout: float,
         grad_checkpoint: bool,
         head_hidden: int,
+        fg_head: bool,
         share_slot_weights: bool,
         num_classes: int,
         grid_size: int,
@@ -77,7 +81,7 @@ class StellaModel(nn.Module):
             for kind in layers
         )
         self.self_head = SelfHead(
-            d_model=d_model, num_classes=num_classes, hidden_layers=head_hidden
+            d_model=d_model, num_classes=num_classes, fg_head=fg_head, hidden_layers=head_hidden
         )
         self.conn_head = ConnHead(
             d_model=d_model,
@@ -118,6 +122,7 @@ class StellaModel(nn.Module):
             dropout=module_cfg.dropout,
             grad_checkpoint=module_cfg.grad_checkpoint,
             head_hidden=module_cfg.head_hidden,
+            fg_head=module_cfg.fg_head,
             share_slot_weights=module_cfg.share_slot_weights,
             num_classes=cfg.data.num_classes,
             grid_size=cfg.data.grid_size,
@@ -166,6 +171,7 @@ class StellaModel(nn.Module):
             class_logit=zeros((batch, side, side, classes)),
             self_coord=zeros((batch, side, side, 2)),
             end_logit=zeros((batch, side, side)),
+            fg_logit=zeros((batch, side, side)),
             exist_logit=zeros((batch, side, side, slots)),
             conn_dir=zeros((batch, side, side, slots, 2)),
         )
@@ -174,12 +180,13 @@ class StellaModel(nn.Module):
         self, output: ModelOutput, index: int, cells: torch.Tensor, tokens: torch.Tensor
     ) -> None:
         rows, cols = cells[:, 0], cells[:, 1]
-        class_logit, self_coord, end_logit = self.self_head(tokens[:, 0])
+        class_logit, self_coord, end_logit, fg_logit = self.self_head(tokens[:, 0])
         exist_logit, conn_dir = self.conn_head(tokens[:, 1:])
         output.node_mask[index, rows, cols] = True
         output.class_logit[index, rows, cols] = class_logit.float()
         output.self_coord[index, rows, cols] = self_coord.float()
         output.end_logit[index, rows, cols] = end_logit.float()
+        output.fg_logit[index, rows, cols] = fg_logit.float()
         output.exist_logit[index, rows, cols] = exist_logit.float()
         output.conn_dir[index, rows, cols] = conn_dir.float()
 

--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -57,6 +57,7 @@ def test_empty_output_decodes_to_empty_list():
         class_logit=torch.zeros((side, side, classes)),
         self_coord=torch.zeros((side, side, 2)),
         end_logit=torch.zeros((side, side)),
+        fg_logit=torch.zeros((side, side)),
         exist_logit=torch.zeros((side, side, slots)),
         conn_dir=torch.zeros((side, side, slots, 2)),
     )
@@ -202,3 +203,38 @@ def test_simplify_removes_collinear_points():
     assert len(decoded) == 1
     assert len(decoded[0]["points"]) == 2  # 직선이므로 양 끝만 남는다
     assert covered_fraction(points, decoded) > 0.98
+
+
+def test_fg_thresh_path_matches_argmax_path_on_gt():
+    """`decode.fg_thresh >= 0`이면 배경 필터가 **이진 로짓**으로 바뀐다 (E12).
+
+    게이트의 `ceiling_gt`는 기본값(`fg_thresh=-1`)으로만 돌아 이 새 경로를 한 번도 타지 않는다.
+    GT를 주입하면 두 경로가 같은 셀을 고르므로, 결과가 어긋나면 새 경로가 틀린 것이다.
+    """
+    lines = [
+        {"class": 3, "points": np.array([[30.0, 100.0], [220.0, 100.0]], dtype=np.float32)},
+        {"class": 5, "points": np.array([[60.0, 20.0], [60.0, 200.0]], dtype=np.float32)},
+    ]
+    base_cfg = make_cfg()
+    base = decode_gt(base_cfg, build_instance(base_cfg.decode, base_cfg), lines)
+    fg_cfg = make_cfg()
+    fg_cfg.decode.fg_thresh = 0.5  # 이진 확률 경로
+    fg = decode_gt(fg_cfg, build_instance(fg_cfg.decode, fg_cfg), lines)
+    assert len(fg) == len(base) == 2
+    for got, want in zip(
+        sorted(fg, key=lambda d: d["class"]), sorted(base, key=lambda d: d["class"])
+    ):
+        assert got["class"] == want["class"]
+        assert np.allclose(got["points"], want["points"])
+
+
+def test_fg_thresh_rejects_cells_the_binary_head_calls_background():
+    """이진 로짓이 낮으면 정점이 생기지 않아야 한다 — 필터가 실제로 그 값을 본다는 확인."""
+    cfg = make_cfg()
+    cfg.decode.fg_thresh = 0.5
+    decoder = build_instance(cfg.decode, cfg)
+    points = np.array([[30.0, 100.0], [220.0, 100.0]], dtype=np.float32)
+    targets = encode_scene([{"class": 3, "points": points}])
+    output = gt_model_output(targets, cfg.data.num_classes, cfg.model.num_conn_slots)
+    output.fg_logit[:] = -10.0  # 전부 "배경"이라 부른다
+    assert decoder(output[0]) == []

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -45,7 +45,12 @@ def test_heads_survive_module_apply():
     모델을 장치로 옮기는 순간 죽는다. 조립 테스트로는 안 잡혀서 여기서 직접 시험한다."""
     from stella.model.heads import ConnHead, SelfHead
 
-    for head in (SelfHead(d_model=32, num_classes=12), ConnHead(d_model=32, num_slots=2)):
+    heads = [
+        SelfHead(d_model=32, num_classes=12, fg_head=False),
+        SelfHead(d_model=32, num_classes=12, fg_head=True),  # 전경 헤드도 같은 계약을 지켜야 한다
+        ConnHead(d_model=32, num_slots=2),
+    ]
+    for head in heads:
         head.to(torch.float64).float()  # 예약 메서드를 가리면 여기서 TypeError가 난다
     shared = ConnHead(d_model=32, num_slots=2, share_slots=True).float()
     split = ConnHead(d_model=32, num_slots=2, share_slots=False).float()
@@ -170,8 +175,44 @@ def _imperfect_output(targets: dict, cfg):
         class_logit=torch.zeros((*shape, classes)),
         self_coord=torch.zeros((*shape, 2)),
         end_logit=torch.zeros(shape),
+        fg_logit=torch.zeros(shape),
         exist_logit=torch.zeros((*shape, slots)),
         conn_dir=torch.zeros((*shape, slots, 2)),
     )
     output.conn_dir[..., 0] = 1.0
     return output
+
+
+def test_fg_head_is_off_by_default_and_costs_nothing():
+    """`fg_head=False`면 파라미터가 **아예 생기지 않아야** 한다.
+
+    끈 상태가 기존 실행과 초기화까지 같아야 E12 arm과 대조군을 비교할 수 있다. 로짓만 0으로
+    두고 MLP는 만들어 두면 난수 소비 순서가 달라져 그 비교가 무너진다.
+    """
+    from stella.model.heads import SelfHead
+
+    off = SelfHead(d_model=32, num_classes=12, fg_head=False)
+    on = SelfHead(d_model=32, num_classes=12, fg_head=True)
+    assert off.fg_mlp is None
+    assert sum(p.numel() for p in on.parameters()) > sum(p.numel() for p in off.parameters())
+    tokens = torch.randn(4, 32)
+    for head in (off, on):
+        class_logit, coord, end_logit, fg_logit = head(tokens)
+        assert class_logit.shape == (4, 12)
+        assert coord.shape == (4, 2)
+        assert end_logit.shape == (4,) and fg_logit.shape == (4,)
+    assert torch.count_nonzero(off(tokens)[3]) == 0  # 끄면 전경 로짓은 항상 0
+
+
+def test_fg_loss_is_skipped_when_weight_is_zero():
+    """`w_fg=0`이면 전경 항이 손실 총합을 바꾸지 않는다 — 기존 실행과 값이 같아야 한다."""
+    cfg = get_config()
+    cfg.data.image_size = IMAGE
+    targets = make_targets()
+    output = _imperfect_output(targets, cfg)
+    base = build_instance(cfg.loss.self_slot, cfg)(output, targets)
+    cfg.loss.self_slot.w_fg = 1.0
+    lifted = build_instance(cfg.loss.self_slot, cfg)(output, targets)
+    assert float(base["fg"]) == 0.0
+    assert torch.allclose(base["total"], lifted["total"] - lifted["fg"])
+    assert float(lifted["fg"]) > 0.0  # 켜면 실제로 계산된다


### PR DESCRIPTION
## 왜

디코더가 정점을 만들 때 실제로 묻는 것은 **"전경이냐" 하나**뿐이다 (`decode/vertices.py`의
`argmax != 0`). 그런데 12지 CE가 그 판정과 종류 분류를 **겸한다**. 손실의 대부분은 흔한
클래스끼리의 혼동이 먹는데, 그 오류는 정점을 살리므로 디코더에 덜 치명적이다.
**치명적인 오류와 덜 치명적인 오류가 한 항에서 경쟁**하고 있다.

실측: 클래스 오류의 **68%가 "배경이라 부름"** (called_bg 0.204 vs wrong_fg 0.094, E07).
디코더는 그 68%에 해당하는 정점을 아예 잃는다.

### E09가 닫은 길

가중 **재분배**로는 안 된다는 것이 확정됐다:

| power | 0 (대조군) | 0.25 | 0.5 | 1.0 |
| --- | --- | --- | --- | --- |
| `class_fg` | 0.4511 | 0.3739 (−17%) | 0.2607 (−42%) | 0.0657 (−85%) |
| `f1` | 0.1737 | 0.1564 | 0.1255 | 0.1055 |

단조 감소이고 대조군이 곧 power=0이므로 **더 약한 지점도 없다.** 재분배는 전경 예산의 총량을
못 늘리고 흔한 클래스를 희생할 뿐이다. 그래서 **분리**한다.

## 손잡이 — 전부 기본값 "끔" = 기존 동작과 비트 동일

| 손잡이 | 기본 | 하는 일 |
| --- | --- | --- |
| `model.fg_head` | `False` | 전경 로짓 1채널. **끄면 `fg_mlp`를 아예 만들지 않는다** |
| `loss.self_slot.w_fg` | `0.0` | 전경 BCE 가중. 0이면 **계산 자체를 건너뛴다** |
| `loss.self_slot.fg_pos_weight` | `1.0` | 선택 셀의 ~70%가 배경이라 양성 쪽을 들 수 있게 |
| `decode.fg_thresh` | `-1.0` | 음수면 기존 `argmax != 0`, 0 이상이면 **이진 확률로 거른다** |
| `cellstat.fg_acc` | — | 이진 헤드 기준 전경 비율 (지표는 더하고 지우지 않는다) |

**로짓만 0으로 두고 MLP는 만들어 두는 방식을 쓰지 않았다.** 그러면 난수 소비 순서가 달라져
대조군과의 비교가 무너진다. 파라미터 수로 확인: `False` 95,365,395 / `True` 95,431,444.

## 배선하며 걸린 것

- `ChainDecoder.from_cfg`가 DecodeConfig 필드를 **전부** `__init__`에 넘긴다 → config에 필드를
  더하면 그쪽 서명도 같이 고쳐야 한다 (`test_build`가 잡았다).
- `ModelOutput` 필드 추가로 **생성 지점 4곳**이 깨졌다. 둘이 중요했다:
  - `decode/cache.py` — **옛 예측 캐시엔 `fg_logit`이 없다.** 없으면 0으로 채운다
    (게이트의 decode 검사가 그 캐시를 쓴다).
  - `model/inject.py` — GT 주입은 전경도 GT대로 확신해야 **천장 0.976이 유지된다.**

## 게이트가 못 보던 구멍

**`ceiling_gt`는 기본값(`fg_thresh=-1`)으로만 돌아 새 디코더 경로를 한 번도 타지 않는다** —
이 PR의 핵심이 게이트 밖에 있었다. 테스트 2개로 덮었다:

1. GT를 주입하면 `fg_thresh=0.5` 경로와 `argmax != 0` 경로가 **같은 결과**를 내야 한다.
2. 이진 로짓을 −10으로 깔면 정점이 **안 생겨야** 한다 (필터가 실제로 그 값을 본다는 확인).

계약 테스트 2개도 추가 — "끄면 파라미터가 안 는다", "`w_fg=0`이면 `total`이 그대로다".

## 게이트 — 6개 전부 통과

| 검사 | 결과 |
| --- | --- |
| pytest (101개) / ruff / format / configs | PASS |
| `ceiling_gt` | PASS f1 **0.9720** |
| `model_regress` | PASS f1 **0.1016** |

## 다음

큐에 E12 4 arm이 대기 중이다 — `bin` · `bin_pw2`(pos_weight 2) · `bin_keep12`(헤드만 추가하고
디코더는 기존 방식 — **헤드 추가 효과만 분리**) · `bin_w05`. 대조군은 `U2_ref`(새 기본값 기준선),
볼 지표는 `fg_acc` → `vertex_recall` → `f1`.