### PR TITLE
arm 타임아웃 6시간 → 24시간 — 정상 실행 셋을 죽이고 있었다

### DIFF
--- a/scripts/run_experiments.py
+++ b/scripts/run_experiments.py
@@ -42,7 +42,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--config", default="configs.unit")
     parser.add_argument("--arms", nargs="+", required=True)
     parser.add_argument("--gpus", default="0,1,2,3")
-    parser.add_argument("--timeout", type=int, default=21600, help="arm 하나의 상한(초)")
+    # **폭주 방지 장치이지 일정 관리 도구가 아니다.** 6시간(21600)으로 두었다가 정상 실행 셋을
+    # SIGKILL 했다 — U arm 실측이 단독 4.3~6.9 h이고 4 arm 경합에서는 에폭당 85분(≈14 h)까지 간다.
+    # 24시간을 넘기는 U arm은 정상이 아니므로 그때는 죽이는 것이 맞다.
+    parser.add_argument(
+        "--timeout", type=int, default=86400, help="arm 하나의 상한(초). 폭주 방지용"
+    )
     return parser.parse_args()
 
 
@@ -106,6 +111,9 @@ def reap(job: dict, timeout: int) -> bool:
     if code is None and time.time() - job["start"] < timeout:
         return False
     if code is None:
+        # 상한 초과로 **우리가** 죽인 것이다. code=-9만 남기면 외부 요인처럼 보여 원인 추적이
+        # 몇 시간씩 샌다(실제로 그랬다). 누가 죽였는지 로그에 분명히 적는다.
+        print(f"[runner] TIMEOUT {job['tag']} — 상한 {timeout}s 초과로 러너가 죽였다", flush=True)
         job["process"].kill()
         job["process"].wait()
         code = -9


### PR DESCRIPTION
## 증상

학습이 `code=-9`(SIGKILL)로 조용히 죽었다. **세 번** 겪고서야 패턴이 보였다.

| 실행 | 시작 | 죽은 시각 | 경과 |
| --- | --- | --- | --- |
| `U2_ref` | 14:58 | 20:58 | **정확히 360분** |
| `E10_rot10` · `E10_w9` | 18:05 | 00:05 | **정확히 6시간** |

원인을 찾느라 OOM·`systemd-oomd`·journal을 뒤졌다. **범인은 우리 러너였다.**

## 원인

`run_experiments.py --timeout` 기본값 **21600초 = 6시간**. `reap()`이 초과분을
`process.kill()` 한다.

**이 값은 폭주 방지 장치인데 U arm의 정상 소요와 겹쳐 있었다.** 실측으로 U arm은 단독
4.3~6.9 h이고, 4 arm이 22코어를 나눠 쓰면 에폭당 85분(≈14 h)까지 간다. 즉 **건강한 실행이
체계적으로 6시간마다 학살당하고 있었다.**

### 왜 놓쳤나

같은 날 오전에 **"U arm = 2.5 h"라는 틀린 추정을 실측으로 고쳤다**(SKILL 3.2 표).
그런데 **그 추정 위에 서 있던 타임아웃 6시간은 같이 훑지 않았다.**
2.5 h 가정에서 6시간은 2.4배 여유였지만, 실제 6.9 h 앞에서는 사형선고다.

> **실측으로 어떤 값을 고치면, 그 값에서 파생된 상수도 같이 훑는다.**

대가: 3개 실행 · 약 **15 GPU시간**.

## 수정

- 기본값 **86400(24시간)**. 24시간을 넘는 U arm은 정상이 아니므로 그때는 죽는 것이 맞다.
- **리퍼가 죽일 때 로그에 크게 남긴다**:
  `[runner] TIMEOUT <tag> — 상한 Ns 초과로 러너가 죽였다`
  `code=-9`만 남으면 외부 요인처럼 보인다. 오늘 그것 때문에 OOM을 뒤졌다.

`dispatch.py`는 `--timeout`을 넘기지 않으므로 이 기본값을 그대로 쓴다 — 한 곳만 고치면 된다.

## 응급 조치 (이 PR 밖, 이미 수행)

- `E12_bin`은 01:00에 죽을 예정이었다 → **러너만 SIGTERM으로 죽여 리퍼를 뗐다.**
  고아가 된 학습 프로세스는 계속 돈다(체크포인트·지표는 학습이 직접 쓴다). 29분 남기고 살렸다.
- 죽은 E10 2 arm은 `--timeout 86400`으로 재실행.
- 디스패처는 **중단** — 이 PR이 병합돼야 안전하게 다시 켠다.

## 게이트 — 6개 전부 통과

| 검사 | 결과 |
| --- | --- |
| pytest / ruff / format / configs | PASS |
| `ceiling_gt` | PASS f1 **0.9720** |
| `model_regress` | PASS f1 **0.1016** |