### PR TITLE
캐시가 fg_logit 을 잃고 있었다 — D 트랙에서 전경 헤드가 통째로 사라졌다

### DIFF
--- a/stella/decode/cache.py
+++ b/stella/decode/cache.py
@@ -15,6 +15,8 @@ import torch
 from stella.model.stella import ModelOutput
 
 SPARSE_KEYS = ("heat", "class_logit", "coord", "end", "exist", "dir")
+# 나중에 생긴 키. **옛 캐시에는 없다** — 없으면 0으로 채운다(그 모델엔 전경 헤드가 없었다).
+OPTIONAL_KEYS = ("fg",)
 BACKGROUND_LOGIT = -30.0  # 비노드 셀의 히트맵 로짓 — sigmoid ~ 0
 
 
@@ -32,6 +34,7 @@ def save_prediction(path: Path, output: ModelOutput, instances: list[dict]) -> N
         end=arrays["end_logit"][rows, cols].astype(np.float16),
         exist=arrays["exist_logit"][rows, cols].astype(np.float16),
         dir=arrays["conn_dir"][rows, cols].astype(np.float16),
+        fg=arrays["fg_logit"][rows, cols].astype(np.float16),
         **_pack_instances(instances),
     )
 
@@ -40,6 +43,7 @@ def load_prediction(path: Path, shape: dict) -> tuple[ModelOutput, list[dict]]:
     """shape: {"grid_size", "num_classes", "num_slots"} — dense 버퍼 크기를 정한다."""
     with np.load(path) as data:
         sparse = {key: data[key] for key in ("cells", *SPARSE_KEYS)}
+        sparse |= {key: data[key] for key in OPTIONAL_KEYS if key in data}
         instances = _unpack_instances(data)
     return _to_dense(sparse, shape), instances
 
@@ -59,7 +63,9 @@ def _to_dense(sparse: dict, shape: dict) -> ModelOutput:
         conn_dir=torch.zeros((side, side, slots, 2)),
     )
     output.node_mask[rows, cols] = True
-    for key, field in zip(SPARSE_KEYS, _DENSE_FIELDS):
+    for key, field in zip((*SPARSE_KEYS, *OPTIONAL_KEYS), _DENSE_FIELDS):
+        if key not in sparse:  # 옛 캐시 — 그 필드는 0으로 남는다
+            continue
         getattr(output, field)[rows, cols] = torch.from_numpy(sparse[key].astype(np.float32))
     return output
 
@@ -71,6 +77,7 @@ _DENSE_FIELDS = (
     "end_logit",
     "exist_logit",
     "conn_dir",
+    "fg_logit",  # OPTIONAL_KEYS 와 짝이다 — 순서를 맞춰 둔다
 )
 
 

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -130,3 +130,55 @@ def test_cached_prediction_decodes_same_as_direct(tmp_path):
     cached = decoder(loaded)
     assert len(direct) == len(cached) == 1
     assert np.allclose(direct[0]["points"], cached[0]["points"], atol=0.05)
+
+
+def test_cache_round_trip_keeps_fg_logit(tmp_path):
+    """캐시가 `fg_logit`을 잃으면 **D 트랙에서 전경 헤드가 통째로 사라진다.**
+
+    실제로 그렇게 당했다: `fg_logit`을 `ModelOutput`에는 넣고 희소 캐시 키에는 안 넣어서,
+    캐시를 거친 예측은 전부 0이 됐다. `sigmoid(0)=0.5`라 `fg_thresh=0.5` 경로에서
+    **정점이 하나도 안 남아 f1이 0**이 됐다. 게이트는 기본값(`fg_thresh=-1`)으로만 돌아 못 잡는다.
+    """
+    cfg = get_config()
+    cfg.data.image_size = IMAGE
+    encoder = ChainEncoder(
+        image_size=IMAGE, grid_stride=STRIDE, num_classes=12, max_degree=2, supersample=1
+    )
+    target = encoder.encode([piece(3, [[30.0, 100.0], [220.0, 100.0]])])
+    targets = {k: torch.from_numpy(v).unsqueeze(0) for k, v in target.items()}
+    output = gt_model_output(targets, cfg.data.num_classes, cfg.model.num_conn_slots)
+    save_prediction(tmp_path / "a.npz", output[0], [])
+    shape = {"grid_size": IMAGE // STRIDE, "num_classes": 12, "num_slots": 2}
+    loaded, _ = load_prediction(tmp_path / "a.npz", shape)
+
+    node = output[0].node_mask
+    assert torch.count_nonzero(output[0].fg_logit[node]) > 0  # GT 주입은 전경을 확신한다
+    assert torch.allclose(loaded.fg_logit[node], output[0].fg_logit[node], atol=0.05)
+
+    cfg.decode.fg_thresh = 0.5  # 이진 헤드로 거르는 경로 — 캐시를 거쳐도 같아야 한다
+    decoder = build_instance(cfg.decode, cfg)
+    direct, cached = decoder(output[0]), decoder(loaded)
+    assert len(direct) == len(cached) == 1
+    assert np.allclose(direct[0]["points"], cached[0]["points"], atol=0.05)
+
+
+def test_old_cache_without_fg_still_loads(tmp_path):
+    """`fg` 키가 없는 **옛 캐시**도 읽혀야 한다 — 그 모델엔 전경 헤드가 없었다."""
+    import numpy as _np
+
+    cfg = get_config()
+    cfg.data.image_size = IMAGE
+    encoder = ChainEncoder(
+        image_size=IMAGE, grid_stride=STRIDE, num_classes=12, max_degree=2, supersample=1
+    )
+    target = encoder.encode([piece(3, [[30.0, 100.0], [220.0, 100.0]])])
+    targets = {k: torch.from_numpy(v).unsqueeze(0) for k, v in target.items()}
+    output = gt_model_output(targets, cfg.data.num_classes, cfg.model.num_conn_slots)
+    save_prediction(tmp_path / "a.npz", output[0], [])
+    with _np.load(tmp_path / "a.npz") as data:  # fg 키만 뺀 옛 형식으로 다시 쓴다
+        kept = {k: data[k] for k in data.files if k != "fg"}
+    _np.savez_compressed(tmp_path / "old.npz", **kept)
+    shape = {"grid_size": IMAGE // STRIDE, "num_classes": 12, "num_slots": 2}
+    loaded, _ = load_prediction(tmp_path / "old.npz", shape)
+    assert torch.count_nonzero(loaded.fg_logit) == 0  # 없으면 0으로 남는다
+    assert len(build_instance(cfg.decode, cfg)(loaded)) == 1  # 기본 경로는 멀쩡하다


### PR DESCRIPTION
## 증상

`E12_bin_pw2`의 예측을 캐시로 덤프해 radius 스윕을 돌렸더니 **모든 반경에서 f1 = 0.0000**.

## 원인

E12(PR #13)에서 `fg_logit`을 `ModelOutput`에는 추가했지만 **희소 캐시의 저장 키
`SPARSE_KEYS`에는 넣지 않았다.** 그래서:

1. 캐시를 거친 예측은 `fg_logit`이 전부 0
2. `sigmoid(0) = 0.5`
3. `fg_thresh=0.5` 조건 `> 0.5`가 **어디서도 참이 아니다** → 정점 0개 → f1 0

**D 트랙에서는 전경 헤드가 통째로 없는 것과 같았다.**

### 게이트가 못 잡은 이유

- `ceiling_gt`·`model_regress`는 **기본값(`fg_thresh=-1`)으로만** 돈다 → 새 경로를 안 탄다.
- PR #13에서 **일부러 추가했던** `fg_thresh` 테스트는 `gt_model_output`을 **직접** 썼다 →
  캐시를 거치지 않는다.

모델→손실→디코더는 챙겼는데 **모델→캐시→디코더**를 빠뜨렸다.
**새 필드를 만들면 그 필드가 지나는 모든 경계를 훑어야 한다.**

## 수정

`OPTIONAL_KEYS = ("fg",)` — 저장·복원하되 **옛 캐시에 키가 없으면 0으로 남긴다.**
그 모델들엔 전경 헤드가 없었으므로 0이 올바른 기본값이다(`gt_val320`·`reff_ep11_val200`이
게이트의 decode 검사에 쓰인다 — 깨지면 안 된다).

## 회귀 테스트 2개

1. **캐시 왕복이 `fg_logit`을 보존**하고, `fg_thresh=0.5` 경로가 직접 디코딩과 같은 결과를 낸다.
2. **`fg` 키 없는 옛 캐시**도 읽히고 기본 경로가 멀쩡하다.

## 게이트 — 6개 전부 통과

| 검사 | 결과 |
| --- | --- |
| pytest / ruff / format / configs | PASS |
| `ceiling_gt` | PASS f1 **0.9720** |
| `model_regress` | PASS f1 **0.1016** |