### PR TITLE
judge_round — 미완주 실행을 완주 대조군과 비교하지 않는다

### DIFF
--- a/scripts/judge_round.py
+++ b/scripts/judge_round.py
@@ -42,6 +42,7 @@ ADOPT_MARGIN = 0.10  # 상대 +10% 이상 채택 (규칙 3)
 REJECT_MARGIN = -0.10  # 상대 −10% 이하 기각
 MOVE_MARGIN = 0.05  # 지목 지표가 "움직였다"의 하한 (규칙 4). 측정 잡음보다 크게 잡았다
 VERDICT_NOTE = {
+    "partial": "미완주",
     "adopt": "채택",
     "hold": "보류 — f1은 올랐으나 지목 지표가 안 움직였다. 재현 필요",
     "neutral": "무효",
@@ -97,9 +98,15 @@ def judge_row(row: dict, control: dict, watch: str) -> dict:
     primary_rel = relative_change(row.get(PRIMARY), control.get(PRIMARY))
     watch_rel = relative_change(row.get(watch), control.get(watch))
     tracked = control.get(watch) is not None  # 그 지표가 로그에 찍히기는 하는가
-    verdict = (
-        "control" if row["name"] == control["name"] else verdict_of(primary_rel, watch_rel, tracked)
-    )
+    if row["name"] == control["name"]:
+        verdict = "control"
+    elif row["epochs"] < control["epochs"]:
+        # **미완주를 완주한 대조군과 비교하면 안 된다.** 학습 곡선의 다른 지점을 견주는 것이라
+        # 일찍 좋다가 나빠지는 실행에 정반대로 속는다. 실측으로 당했다:
+        # dispatch 가 E14(에폭 5·3)를 완주한 대조군(에폭 10)과 비교해 "채택"으로 판정했다.
+        verdict = "partial"
+    else:
+        verdict = verdict_of(primary_rel, watch_rel, tracked)
     return {**row, "primary_rel": primary_rel, "watch_rel": watch_rel, "verdict": verdict}
 
 
@@ -166,6 +173,13 @@ def fmt_percent(value) -> str:
 def summary_line(judged: list[dict]) -> str:
     adopted = [row["name"] for row in judged if row["verdict"] == "adopt"]
     held = [row["name"] for row in judged if row["verdict"] == "hold"]
+    partial = [row["name"] for row in judged if row["verdict"] == "partial"]
+    if partial:  # 아직 도는 실행이 있으면 판정 자체가 이르다 — 조용히 넘어가지 않는다
+        return (
+            f"**미완주 {len(partial)}건이 섞였다** ({', '.join(partial)}) — 대조군보다 에폭이 "
+            f"적어 판정에서 뺐다. 완주 뒤 다시 돌려라."
+            + (f" · 채택 {len(adopted)}건" if adopted else "")
+        )
     if adopted:
         return f"**채택 {len(adopted)}건**: {', '.join(adopted)}" + (
             f" · 보류 {len(held)}건" if held else ""


### PR DESCRIPTION
## 실측으로 당했다

`dispatch.py`의 자동 판정이 이렇게 냈다:

| arm | ep | f1 | f1 Δ% | 판정 |
| --- | --- | --- | --- | --- |
| `E14_swin` | **5** | 0.3120 | +46.7 | **채택** ← |
| `E14_cnxlarge` | **3** | 0.2596 | +22.1 | **채택** ← |
| `E08_alpha075` (대조군) | **10** | 0.2126 | — | 대조군 |

**에폭 5·3짜리를 에폭 10 대조군과 비교했다.** 학습 곡선의 다른 지점을 견주는 것이라
판정이 성립하지 않는다.

이번에는 신호가 워낙 커서(절반 학습에 +47%) 결론이 같겠지만, **일찍 좋다가 나빠지는 실행이면
정반대로 속는다.** 그리고 그 판정을 근거로 디스패처가 멈춰 "사람이 반영 여부를 정하라"고 한다 —
잘못된 근거로 사람을 부르는 것이다.

## 왜 손으로 할 때는 안 당했나

어제 `U2_ref`가 SIGKILL로 6에폭에서 죽은 뒤로, **판정할 때마다 `epoch == 9`를 먼저 확인**하는
습관을 들였고 STATE에도 적어 뒀다. 그런데 **자동 경로에는 그 방어가 없었다.**
사람이 지키는 규칙은 지켜지지 않고 코드가 지키는 규칙만 지켜진다.

## 수정

- 대조군보다 에폭이 적으면 **`partial`("미완주")** 로 표시하고 **채택 집계에서 뺀다.**
- 요약 줄이 먼저 경고한다:
  **"미완주 N건이 섞였다 (…) — 대조군보다 에폭이 적어 판정에서 뺐다. 완주 뒤 다시 돌려라."**

같은 명령의 출력이 **"채택 2건" → "미완주 2건이 섞였다"** 로 바뀌는 것을 확인했다.

## 게이트

pytest · ruff · format · configs 통과. decode 검사(`ceiling_gt`·`model_regress`)는 이 변경의
영향권 밖이다 — 판정 스크립트만 건드렸고 디코더 경로를 타지 않는다.