### PR TITLE
judge_round — 디코더 설정이 다른 실행끼리 비교하지 않는다

### DIFF
--- a/scripts/judge_round.py
+++ b/scripts/judge_round.py
@@ -42,6 +42,7 @@ ADOPT_MARGIN = 0.10  # 상대 +10% 이상 채택 (규칙 3)
 REJECT_MARGIN = -0.10  # 상대 −10% 이하 기각
 MOVE_MARGIN = 0.05  # 지목 지표가 "움직였다"의 하한 (규칙 4). 측정 잡음보다 크게 잡았다
 VERDICT_NOTE = {
+    "mismatch": "디코더 불일치",
     "partial": "미완주",
     "adopt": "채택",
     "hold": "보류 — f1은 올랐으나 지목 지표가 안 움직였다. 재현 필요",
@@ -100,6 +101,10 @@ def judge_row(row: dict, control: dict, watch: str) -> dict:
     tracked = control.get(watch) is not None  # 그 지표가 로그에 찍히기는 하는가
     if row["name"] == control["name"]:
         verdict = "control"
+    elif row.get("decode") and control.get("decode") and row["decode"] != control["decode"]:
+        # **디코더 설정이 다르면 f1을 비교할 수 없다.** config 기본값을 바꾸면 그 시점 이후
+        # 실행만 새 설정으로 검증하므로 두 집단이 조용히 섞인다(radius 2→24에서 실제로 당했다).
+        verdict = "mismatch"
     elif row["epochs"] < control["epochs"]:
         # **미완주를 완주한 대조군과 비교하면 안 된다.** 학습 곡선의 다른 지점을 견주는 것이라
         # 일찍 좋다가 나빠지는 실행에 정반대로 속는다. 실측으로 당했다:
@@ -173,7 +178,15 @@ def fmt_percent(value) -> str:
 def summary_line(judged: list[dict]) -> str:
     adopted = [row["name"] for row in judged if row["verdict"] == "adopt"]
     held = [row["name"] for row in judged if row["verdict"] == "hold"]
+    mismatch = [row for row in judged if row["verdict"] == "mismatch"]
     partial = [row["name"] for row in judged if row["verdict"] == "partial"]
+    if mismatch:  # 판정 자체가 성립하지 않는다 — 무엇이 다른지 찍어 준다
+        control_decode = next((r["decode"] for r in judged if r["verdict"] == "control"), {})
+        detail = "; ".join(f"{r['name']}: {r['decode']}" for r in mismatch)
+        return (
+            f"**디코더 설정이 달라 판정할 수 없다 {len(mismatch)}건** — 대조군 {control_decode} vs "
+            f"{detail}. 같은 설정으로 예측을 덤프해 `eval_decode.py` 로 다시 재라."
+        )
     if partial:  # 아직 도는 실행이 있으면 판정 자체가 이르다 — 조용히 넘어가지 않는다
         return (
             f"**미완주 {len(partial)}건이 섞였다** ({', '.join(partial)}) — 대조군보다 에폭이 "

--- a/stella/eval/runlog.py
+++ b/stella/eval/runlog.py
@@ -7,9 +7,11 @@
 """
 
 import csv
+import json
 from pathlib import Path
 
 EPOCH_KEY = "epoch"
+DECODE_KEYS = ("radius", "heatmap_thresh", "fg_thresh", "purity_thresh", "min_class_prob")
 PRESENCE_KEY = "val/inst/f1"  # 이 값이 있어야 "평가가 끝난 에폭"이다
 
 
@@ -35,7 +37,31 @@ def tail_mean(run: Path, tail: int, keys: tuple[str, ...]) -> dict | None:
         return None
     window = epochs[-tail:]
     values = {key: mean_of(merged, window, key) for key in keys}
-    return {"name": run.name, "path": str(run), "epochs": len(epochs), **values}
+    return {
+        "name": run.name,
+        "path": str(run),
+        "epochs": len(epochs),
+        "decode": decode_signature(run),
+        **values,
+    }
+
+
+def decode_signature(run: Path) -> dict:
+    """그 실행이 **검증에 쓴 디코더 설정**. 판정에서 실행끼리 같은지 확인하는 데 쓴다.
+
+    config 기본값을 바꾸면 그 시점을 기준으로 실행이 두 집단으로 갈린다 — 이전 실행은 옛
+    설정으로, 이후 실행은 새 설정으로 검증한다. 실측으로 당했다: `decode.radius` 기본값을
+    2 → 24로 바꾼 뒤 뜬 백본 실험이 옛 대조군(radius 2)보다 f1이 +50% 높게 나왔는데,
+    같은 반경으로 맞춰 재니 **+1.3%(무효)** 였다. 사람의 주의로는 못 막는다.
+    """
+    path = run / "config.json"
+    if not path.exists():
+        return {}
+    try:
+        decode = json.loads(path.read_text(encoding="utf-8")).get("decode", {})
+    except (OSError, ValueError):
+        return {}
+    return {key: decode[key] for key in DECODE_KEYS if key in decode}
 
 
 def merge_by_epoch(path: Path) -> dict[int, dict]:


### PR DESCRIPTION
## 하마터면 틀린 돌파를 보고할 뻔했다

PR #16이 `decode.radius` 기본값을 2 → 24로 바꿨다. 실행 폴더는 시작 시점의 config를 고정하므로
**그 이후 뜬 실행만 24로 검증**하고, 이전 실행은 2로 검증한 값을 갖는다. **두 집단이 조용히 섞였다.**

그 결과 백본 실험(radius 24)이 옛 대조군(radius 2)보다 f1 **+64%** 로 나왔고, 나는 이것을
**백본 효과**로 읽고 "절반 학습에 +52%"라고 기록했다.

예측을 덤프해 **같은 반경에서** 다시 재니:

| | radius 2 | radius 24 |
| --- | --- | --- |
| 대조군 `alpha075` | 0.2173 | 0.3589 |
| `E14_cnxlarge` (ep4) | 0.1939 | 0.3634 |
| **Δ** | **−10.8%** | **+1.3% → 무효** |

**백본은 중립이거나 오히려 나빴다.** 상승분은 전부 디코더 몫이었다.

## 수정

- `runlog.tail_mean` 이 각 실행의 `config.json` 에서 **디코더 설정 서명**을 함께 낸다:
  `radius` · `heatmap_thresh` · `fg_thresh` · `purity_thresh` · `min_class_prob`.
- 대조군과 서명이 다르면 **`mismatch`("디코더 불일치")** 로 표시하고 채택 집계에서 뺀다.
- 요약 줄이 **무엇이 다른지 그대로 찍고** 다음 행동을 지시한다:
  "같은 설정으로 예측을 덤프해 `eval_decode.py` 로 다시 재라."

같은 명령의 출력이 **"+64.0 채택" → "디코더 설정이 달라 판정할 수 없다 4건"** 으로 바뀌는 것을 확인했다.

## 왜 사람이 못 막나

어제 `focal_alpha` 기본값을 바꿀 때는 **"기본값을 바꾸면 대조군이 죽는다"** 를 확정된 사실로
적고 새 기준선(`U2_ref`)을 돌렸다. 그런데 **오늘 `radius` 를 바꿀 때는 같은 조치를 하지 않았다.**
하루 만에 같은 함정을 밟았다. 규칙을 아는 것으로는 부족하고 **도구가 강제해야 한다.**

오늘 세 번째로 같은 결론에 도달했다 — 미완주 판정(PR #17), 캐시 필드 누락(PR #15), 그리고 이번.

## 게이트

pytest · ruff · format · configs 통과. decode 검사는 이 변경의 영향권 밖이다(판정 스크립트와
`runlog` 만 건드렸다).