### PR TITLE
디코더 후처리 진단 손잡이 — vertices_per_img · min_chain_score

### DIFF
--- a/configs/schema.py
+++ b/configs/schema.py
@@ -201,6 +201,9 @@ class DecodeConfig(ModuleConfig):
     purity_thresh: float = 0.6  # 사슬 순도 하한 — argmax 클래스 일치 비율. 이하면 사슬 폐기
     end_extend: float = 1.0  # 끝 셀에서 끝방향 슬롯으로 연장하는 길이(셀) — 10.3절 끝 연장
     min_points: int = 2  # 이보다 짧은 폴리라인은 버린다 (연장점 포함)
+    # 사슬 평균 점수 하한. `min_points`와 같은 목적(허위 조각 제거)인데 **길이를 안 본다** —
+    # GT 선의 13.3%가 6셀 미만이라 길이로 거르면 그만큼을 구조적으로 포기한다.
+    min_chain_score: float = 0.0  # 0이면 무동작
     simplify_tol: float = 0.0  # >0이면 RDP 단순화 (픽셀)
     # --- 알고리즘 변형 (가설 백로그 A). 기본값은 전부 기존 동작이다 ---
     seed_mode: str = "class_peak"  # "class_peak" | "end_peak" (선의 끝에서 시작, A5)

--- a/scripts/eval_decode.py
+++ b/scripts/eval_decode.py
@@ -37,6 +37,10 @@ DECODE_KEYS = (
     "chain_len",
     "stop_end",
     "stop_nocand",
+    # 이 둘이 짝이다. `stop_nocand`가 클 때 **정점이 모자란 것**과 **있는데 못 엮은 것**을
+    # 가른다 — 처방이 완전히 다르다(검출 vs 디코딩). 비율만 보면 분모를 놓친다.
+    "vertices_per_img",  # 영상당 검출 정점 수
+    "vertex_used",  # 그중 사슬에 쓰인 비율
     "stop_exist",
     "merged_per_img",
 )

--- a/stella/decode/graph.py
+++ b/stella/decode/graph.py
@@ -50,6 +50,7 @@ class ChainDecoder:
         purity_thresh: float,
         end_extend: float,
         min_points: int,
+        min_chain_score: float,
         simplify_tol: float,
         seed_mode: str,
         stop_needs_nocand: bool,
@@ -72,6 +73,7 @@ class ChainDecoder:
         self.purity_thresh = purity_thresh
         self.end_extend = end_extend
         self.min_points = min_points
+        self.min_chain_score = min_chain_score
         self.simplify_tol = simplify_tol
         self.stop_needs_nocand = stop_needs_nocand
         self.align_mode = align_mode
@@ -260,6 +262,12 @@ class ChainDecoder:
         """폴리라인 클래스 = 사슬 클래스(시드의 클래스) — 순도 검사가 다수결 일치를 보증한다."""
         points = np.array([*head_ext, *vertices["point"][chain], *tail_ext])
         if points.shape[0] < self.min_points:
+            return None
+        # 길이 대신 **신뢰도**로 거르는 길. `min_points`를 올리면 허위 조각이 줄지만
+        # 짧은 진짜 선도 같이 버린다(GT의 13.3%가 6셀 미만이다). 점수 하한은 길이와
+        # 무관하게 약한 사슬만 버리므로 짧은 선을 살릴 수 있다.
+        score = float(vertices["score"][chain].mean())
+        if score < self.min_chain_score:
             return None
         pixels = points * self.grid_stride - PIXEL_CENTER_SHIFT
         if self.simplify_tol > 0:

--- a/stella/decode/stats.py
+++ b/stella/decode/stats.py
@@ -49,6 +49,9 @@ class ChainStats:
         result["chains_per_img"] = _ratio(chains, self.counter["images"])
         result["chain_len"] = _ratio(self.counter["chain_cells"], chains)
         result["purity_reject"] = _ratio(self.counter["purity_reject"], self.counter["images"])
+        # 영상당 검출 정점 수. `vertex_used`(쓰인 비율)만으로는 **정점이 모자란 것**과
+        # **엮기에 실패한 것**을 못 가른다 — 분모가 여기 있어야 한다.
+        result["vertices_per_img"] = _ratio(self.counter["vertices"], self.counter["images"])
         result["vertex_used"] = _ratio(self.counter["vertex_used"], self.counter["vertices"])
         result["merged_per_img"] = _ratio(self.counter["merged"], self.counter["images"])
         return result


### PR DESCRIPTION
병목이 "사슬이 왜 끊기는가"로 좁혀졌는데, 기존 보고 열로는 **정점이 모자란 것**과
**있는데 못 엮은 것**을 가를 수 없었다. 비율(`vertex_used`)만 있고 분모가 없었기 때문이다.

## 넣은 것

- **`vertices_per_img`** — 영상당 검출 정점 수. `vertex_used`(그중 쓰인 비율)와 짝이다.
- `eval_decode` 보고 열에 둘 다 추가.
- **`decode.min_chain_score`** — 사슬 평균 점수 하한. 점수가 계산만 되고 **쓰이지 않고 있었다.**

## 이걸로 알게 된 것

| | 모델 | GT 주입 |
| --- | --- | --- |
| 영상당 정점 | **1,289** | **1,604** (모델이 80%) |
| 영상당 사슬 | 51.9 | 35.2 (모델이 147%) |
| 정점당 사슬 | 0.0403 | 0.0220 (**1.83배 조각남**) |
| `vertex_used` | 0.999 | 1.000 |

**정점은 20% 부족한데 조각남은 83% 심하다.** 정점 부족만으로 설명되지 않는다.
그리고 `vertex_used`가 0.999라 **남아도는 정점이 없다** — "후보가 있는데 못 쓴다"는 아니다.

## `min_chain_score` — 기대에 못 미쳤다 (음성 결과)

`min_points`(길이 하한)를 올리면 허위 조각이 줄어 정밀도가 크게 오르지만, **GT 선의 13.3%가
6셀보다 짧아** 그만큼을 구조적으로 포기하게 된다(재현율 −10%). 길이 대신 신뢰도로 거르면
짧은 진짜 선을 살릴 수 있으리라 보고 손잡이를 넣었다.

| `min_chain_score` | f1 | 정밀도 | 재현율 |
| --- | --- | --- | --- |
| 0 (꺼짐) | 0.5408 | 0.4918 | 0.6007 |
| 0.3 (최적) | 0.5453 | 0.5154 | 0.5789 |
| 0.4 | 0.5264 | 0.6742 | 0.4318 |
| 0.5 | 0.3064 | 0.9090 | 0.1843 |

**단독으로 +0.8%뿐이고 0.4를 넘으면 급격히 무너진다.** 같은 목적의 `min_points=6`은 +7.8%다.
사슬 점수가 허위와 진짜를 잘 가르지 못한다는 뜻이다. **기본값 0.0(무동작)으로 두고 손잡이만
남긴다** — 다른 모델에서는 점수 분포가 다를 수 있고, 껐을 때 동작이 이전과 완전히 같다.

## 아직 병합하지 않은 것

`min_points`(2 → 6)와 `merge_gap`(0 → 32)은 **캐시 4개·200장에서 +7.0~8.9%로 일정**하지만
(둘은 튜닝에 안 쓴 캐시), `min_points`가 짧은 GT 선 13.3%를 버리는 거래라는 점을 먼저
문서화하고 별도 PR로 올린다.

코드 변경은 **기본값을 바꾸지 않으므로 기존 동작과 동일**하다. 게이트 8종 통과
(`pytest` 106개 · `ruff` · `format`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011krem6KjCszxY4E16mxXF9