### PR TITLE
드문 차선을 클래스 가중으로 되살린다 — 종류별 평균 +3.4% (안전지대 10.8배)

### DIFF
--- a/configs/schema.py
+++ b/configs/schema.py
@@ -145,12 +145,19 @@ class SelfSlotLossConfig(ModuleConfig):
     class_bg_weight: float = 1.0
     # 희소 클래스 3종(bus_only_lane·safety_zone·bicycle_lane)이 200장에서 한 번도 예측되지
     # 않았다 (E07). 전경 가중을 인스턴스 빈도의 -power 승으로 준다. 0.0 = 가중 없음 (E09)
-    class_freq_power: float = 0.0
+    # **08-19 채택: 0.5.** 반경을 5로 줄이면서 약해진 희소 종류를 학습 쪽에서 되찾는다.
+    # 같은 U 규격 대조군 대비 **종류별 평균 f1 +3.4%** (0.2420 -> 0.2502, 판정 밴드 ±2%),
+    # 안전지대 f1 0.0081 -> 0.0872 · 버스전용차로 0.0263 -> 0.0752. 대가는 없다
+    # (precision −1.4% · correctness +0.9% · coverage +0.5%, 전부 잡음 범위).
+    class_freq_power: float = 0.5
     # 전경 가중의 정규화 방식. "mean" = 평균 1 (E09 의 재분배 — 흔한 클래스를 1 아래로 누른다)
     # "floor" = 1 아래로 내리지 않음 (희소만 올린다). **E09 기각의 원인은 축이 아니라 정규화였다** —
     # `power=0.5` 가 `lane_line` 가중을 0.42 로 눌러 전경 인식이 무너졌다(class_fg -42%).
     # 08-19 사용자 결정: 반경 축소로 약해진 희소 종류는 이 손잡이로 보완한다.
-    class_freq_norm: str = "mean"
+    # **08-19 채택: "floor".** E09 가 이 축을 기각한 원인은 축이 아니라 "mean"(재분배)이었다 —
+    # 희소를 올린 만큼 흔한 클래스를 눌러 `lane_line` 가중이 0.42 가 됐고 전경 인식이
+    # 42% 무너졌다. "floor" 로 바꾸니 `class_fg` 가 0.483 -> 0.471 로 멀쩡하다.
+    class_freq_norm: str = "floor"
     # 전경/배경 이진 BCE (E12). `model.fg_head=True`와 함께 쓴다. 0.0 = 항 자체를 계산하지 않는다.
     w_fg: float = 0.0
     fg_pos_weight: float = 1.0  # 선택 셀의 ~70%가 배경이라 양성 쪽을 들 수 있게 열어 둔다

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -96,8 +96,13 @@ def test_criterion_returns_all_logged_keys():
 
 
 def test_class_weight_is_neutral_without_frequency_power():
-    """가중을 끄면 예전의 단순 평균 CE와 같다 — E09 리팩터가 기본 동작을 바꾸지 않았다."""
+    """가중을 끄면(`power=0`) 단순 평균 CE와 같다 — 가중 경로가 기본 동작을 바꾸지 않는다.
+
+    기본값은 `power=0.5`(08-19 채택)이므로 여기서는 **명시적으로 꺼서** 잰다. 기본값에
+    기대면 기본값이 바뀔 때마다 이 계약이 조용히 다른 것을 재게 된다.
+    """
     cfg = get_config()
+    cfg.loss.self_slot.class_freq_power = 0.0
     cfg.data.image_size = IMAGE
     loss_module = build_instance(cfg.loss.self_slot, cfg)
     assert torch.allclose(loss_module.class_weight, torch.ones(cfg.data.num_classes))
@@ -110,16 +115,33 @@ def test_class_weight_is_neutral_without_frequency_power():
     assert torch.allclose(loss_module(output, targets)["class"], plain)
 
 
-def test_class_freq_power_lifts_rare_classes():
-    """빈도 가중은 희소 클래스를 올리되 전경 평균은 1로 둔다 — 손실 스케일이 안 흔들린다 (E09)."""
+def test_class_freq_mean_redistributes():
+    """`mean` 정규화는 **재분배**다 — 희소를 올린 만큼 흔한 클래스를 1 아래로 누른다.
+
+    E09 가 이 축을 기각한 원인이 바로 이것이다(`lane_line` 가중 0.42 -> class_fg −42%).
+    동작 자체는 유지하되, 그것이 재분배라는 사실을 계약으로 못박는다.
+    """
     cfg = get_config()
     cfg.loss.self_slot.class_freq_power = 0.5
+    cfg.loss.self_slot.class_freq_norm = "mean"
     weight = build_instance(cfg.loss.self_slot, cfg).class_weight
     rare = CLASS_NAMES.index("bus_only_lane")
     common = CLASS_NAMES.index("no_parking_stopping_line")
     assert weight[rare] > 1.0 > weight[common]
     assert torch.allclose(weight[1:].mean(), torch.tensor(1.0))
     assert float(weight[0]) == cfg.loss.self_slot.class_bg_weight
+
+
+def test_class_freq_floor_lifts_rare_without_suppressing_common():
+    """기본값(`floor`)은 희소만 올리고 흔한 클래스는 1.0 그대로 둔다 (08-19 채택)."""
+    cfg = get_config()
+    weight = build_instance(cfg.loss.self_slot, cfg).class_weight
+    rare = CLASS_NAMES.index("bus_only_lane")
+    common = CLASS_NAMES.index("no_parking_stopping_line")
+    assert cfg.loss.self_slot.class_freq_norm == "floor"
+    assert weight[rare] > 1.0
+    assert float(weight[common]) == 1.0
+    assert float(weight[1:].min()) >= 1.0
 
 
 def test_perfect_prediction_drives_losses_to_zero():


### PR DESCRIPTION
## 요약

바로 앞 PR에서 디코더 탐색 반경을 48 px → 20 px로 줄여 **옆 차선으로 넘어가는 예측을 절반
이하로** 줄였는데(6.0% → 2.5%), 그 대가로 **모델이 원래도 거의 못 찾던 드문 차선 3종이 더
나빠졌다.** 반경이 크면 띄엄띄엄 찾은 점을 멀리 건너뛰어 억지로 이어 주던 것이 사라지기
때문이다.

그 보완을 **학습 쪽 클래스 가중**으로 했다. 같은 조건에서 **차선 종류별 평균 점수가
0.2420 → 0.2502 (+3.4%)**, 안전지대는 **10.8배**(0.0081 → 0.0872), 버스전용차로는 **2.9배**
(0.0263 → 0.0752)가 됐고 **대가가 없다**(정밀도 −1.4% · 정확성 +0.9%, 전부 잡음 범위).

이 축은 예전에 한 번 기각됐었다. **원인이 축이 아니라 정규화 방식이었음을 이번에 확인했다.**

## 용어

| 이름 | 뜻 |
| --- | --- |
| **종류별 평균 점수 (`f1_macro`)** | 차선 종류 11개의 F1을 **같은 무게로** 평균한 값. 드문 종류가 죽으면 여기서 드러난다 |
| **전체 점수 (`f1`)** | 선 하나 단위 F1을 전체에 대해 계산. 흔한 종류가 지배한다 |
| **`correctness`(정확성)** | 예측한 점 중 **정답 선 하나 위**에 있는 비율 — 옆 차선으로 갈아탄 예측은 점수를 못 받는다 |
| **`class_fg`(전경 인식)** | 정답 차선 칸을 "배경이 아니다"라고 부른 비율. 이게 무너지면 검출 자체가 무너진다 |
| **U 규격** | 아이디어 비교용 짧은 학습 — 3,000장·10바퀴·GPU 1장 |

## 왜 이 실험을 했나

앞 PR에서 반경을 줄인 뒤 종류별로 뜯어보니, 흔한 차선 8종은 좋아졌는데 **드문 3종이
무너졌다**: 자전거도로 0.044 → 0.007 · 버스전용차로 0.194 → 0.109 · 안전지대 0.074 → 0.065.

디코더 쪽에서 먼저 손을 써 봤다 — "짧아도 살려 주는 종류" 명단에 그 셋을 넣는 것이다.
**오히려 더 나빠졌다**(자전거도로 0.007 → 0.004). 길이 하한을 낮추면 허위 조각이 늘기 때문이다.
그래서 학습 쪽으로 옮겼다.

**가설.** 희소 클래스의 분류 손실 가중을 올리면 그 종류의 셀이 배경으로 눌리지 않고,
종류별 평균 점수가 오른다.
**반증 조건.** `class_fg`(전경 인식)가 내려가면 예전 실패의 재현이므로 기각한다.
**미리 정한 지목 지표.** 종류별 평균 점수(`f1_macro`) → 희소 3종의 개별 점수.

## 무엇을 바꿨나 — 그리고 예전 기각이 왜 틀렸나

| 손잡이 | 기존 → 새 값 | 평범한 말로 |
| --- | --- | --- |
| `loss.self_slot.class_freq_power` | 0.0 → **0.5** | 드문 종류의 분류 오답에 더 큰 벌점 |
| `loss.self_slot.class_freq_norm` | (신설) → **`"floor"`** | **가중치를 1.0 아래로는 내리지 않는다** |

**두 번째가 핵심이다.** 같은 축을 예전에 시험했을 때는 가중치 **평균을 1로 맞추는** 방식이었다.
그건 재분배라서 **드문 종류를 올린 만큼 흔한 종류를 눌렀다** — 가장 흔한 `lane_line`의 가중치가
0.42까지 내려갔고, 모델이 보는 칸의 대다수가 그 종류라 **전경 인식 자체가 42% 무너졌다.**
그래서 "이 축은 해롭다"고 기각됐다.

```
옛 방식(mean):  lane_line 0.42 · bus_only_lane 1.95 · safety_zone 1.85   ← 흔한 것을 누른다
새 방식(floor): lane_line 1.00 · bus_only_lane 2.29 · safety_zone 2.18   ← 드문 것만 올린다
```

기본값은 `"mean"`이 아니라 `"floor"`이지만 **두 방식 모두 남겨 두었다** — 옛 동작을 재현할
수 있어야 과거 실행과 비교가 선다.

## 실험 조건

| 항목 | 값 |
| --- | --- |
| 규격 | **U 규격** — 학습 3,000장 · 10바퀴 · GPU 1장 |
| 대조군 | `E25_ref` — **아무것도 바꾸지 않고** 같은 규격·같은 코드로 완주한 실행 |
| 채점 | 두 실행의 예측을 **검증 700장 캐시로 떠서 같은 디코더 설정으로** 다시 채점. 학습 중 로그의 점수는 실행 시점의 디코더로 계산돼 서로 비교할 수 없다 |
| 판정 밴드 | ±2% (같은 설정으로 두 번 돌린 실행의 차이가 0.1%로 측정됐다) |

## 결과

**읽는 법.** 첫 줄(종류별 평균)이 이 실험이 미리 지목한 지표다. 그 아래 세 줄이 실제로 살아난
종류들이고, 나머지는 "대가가 없다"를 보이는 줄이다. 전부 ↑가 좋다.

| 지표 | 대조군 | 이 PR | 변화 |
| --- | --- | --- | --- |
| **종류별 평균 점수** | 0.2420 | **0.2502** | **+3.4%** |
| 안전지대 | 0.0081 | **0.0872** | **10.8배** |
| 버스전용차로 | 0.0263 | **0.0752** | **2.9배** |
| 자전거도로 | 0.0083 | 0.0114 | 1.4배 |
| 전체 점수 | 0.3156 | 0.3160 | +0.1% |
| 정밀도 | 0.3192 | 0.3147 | −1.4% |
| 정확성 | 0.7931 | 0.7998 | +0.9% |
| **전경 인식** (반증 지표) | 0.4834 | 0.4706 | −2.6% |

## 무엇이 보이는가

1. **지목 지표가 밴드를 넘었고 반증 조건은 걸리지 않았다.** 전경 인식이 −2.6%인데,
   예전 실패 때는 **−42%** 였다. 정규화가 원인이라는 진단이 맞았다.
2. **전체 점수는 제자리(+0.1%)다.** 드문 종류를 살린 이득이 흔한 종류에서 상쇄된다.
   흔한 종류가 전체 점수를 지배하므로 이 축은 **종류별 평균으로만 판정해야 한다.**
3. **자전거도로만 거의 안 움직인다**(1.4배, 절대값 0.011). 가중으로 풀 문제가 아니라
   그 종류의 **표본 자체가 부족**한 쪽으로 보인다 — 다음 라운드의 후보다.

## 판정

**채택.** 미리 정한 지목 지표가 판정 밴드(±2%)를 넘었고, 반증 조건에 걸리지 않았으며,
어떤 지표에서도 밴드를 넘는 손해가 없다.

## 무엇을 바꾸는가

- `configs/schema.py` — `class_freq_power` 0.0 → 0.5 · `class_freq_norm` 신설(`"floor"`).
  두 값 모두 실측 근거를 주석으로 남겼다.
- `tests/test_model.py` — **게이트가 잡은 계약 테스트 두 개를 고쳤다.** 자세한 내용은 아래.

### 딸린 수정 — 게이트가 잡은 것

기본값을 바꾸자 기존 테스트 두 개가 깨졌다. 둘 다 **옛 동작을 계약으로 박아 둔** 것이었다.

- 하나는 "기본값은 가중 없음"을 전제했다 → **명시적으로 꺼서** 재도록 고쳤다.
  기본값에 기대는 계약 테스트는 기본값이 바뀔 때마다 조용히 다른 것을 재게 된다.
- 다른 하나는 "흔한 클래스가 1 아래로 눌린다"를 **요구**했다 — 그게 바로 옛 실패의
  원인인데 테스트가 그것을 지키고 있었다. `mean` 방식용 테스트로 이름을 옮기고,
  새 기본값이 **흔한 클래스를 1.0 그대로 둔다**는 계약을 새로 추가했다.

## 검증 — 관문 12개 전부 통과

| 검사 | 결과 |
| --- | --- |
| pytest (123개) · ruff · format · configs · install | 통과 |
| 정답 주입 상한 `ceiling_gt` | f1 = 0.9441 ≥ 0.93 |
| 학습 모델 회귀 감시 `model_regress` | f1 = 0.3933 ≥ 0.34 |
| 불변식 4종 (거리·버퍼·전경 헤드·튜플 타입) | 통과 |

손실 함수 기본값 변경이라 디코딩 검사(위 둘)의 값은 앞 PR과 같다 — 캐시된 예측을 읽기 때문이다.

## 이 결과의 한계

- **U 규격(3,000장·10바퀴)에서만 확인했다.** 전체 데이터(8,979장·40바퀴)에서도 같은 방향인지는
  지금 도는 전체 학습이 끝난 뒤 확인해야 한다.
- **세기 0.5만 재봤다.** 1.0이 더 나은지는 지금 GPU에서 돌고 있다 — 결과에 따라 값이 바뀔 수 있다.
- 자전거도로는 사실상 회복되지 않았다(0.011).
- 검증셋 기준이다. 테스트셋 2,567장은 최종 보고 전까지 봉인돼 있다.

## 다음 실험 계획

**이 결과가 무엇을 바꿨나.** "정점을 더 많이 찾게 하면 배정이 안 된다"는 벽에 네 번 부딪혔는데
(빈도 역가중·이진 전경 헤드·백본 교체·배경 가중), 이번에 **처음으로 그 축에서 이득이 나왔다.**
단 이득은 전체 점수가 아니라 **종류별 평균**에서만 나온다 — 앞으로 이 축은 그 지표로 판정한다.

**바로 다음 (이미 GPU에서 실행 중)**

| 항목 | 내용 |
| --- | --- |
| **무엇을 묻는가** | 클래스 가중을 두 배로 세게 걸면 더 좋아지는가, 아니면 0.5가 봉우리인가 |
| **조건** | `class_freq_power` 0.5 → 1.0 (정규화는 같은 `floor`) |
| **지목 지표 / 반증** | 종류별 평균 점수. 세기에 따라 단조롭게 나빠지면 축 전체를 한 번에 정리할 수 있다 |
| **규격·시간** | U 규격 · GPU 1장 · 약 4시간 |

**그 뒤의 대기열**

| 순위 | 무엇을 | 왜 지금 이 순위인가 | 규격 |
| --- | --- | --- | --- |
| 1 | **연결 방향 손실의 곡선·가중** (진행 중) | 곡선 교체 쪽이 이미 전체 점수 +2.0%를 냈고 여섯 지표가 모두 같은 방향이다. 가중 20배 쪽 결과를 기다려 함께 판정한다 | U |
| 2 | 전체 데이터 재학습 완주 후 재채점 | 지금 기준선은 옛 평가 기준으로 저장할 모델을 고른 실행이다 | F |
| 3 | 자전거도로 표본 부족 확인 | 가중으로 안 움직이는 유일한 종류다. 학습 데이터에 몇 개나 있는지부터 센다 | — |
