### PR TITLE
D07 — 중복 선을 지울 때 "선을 조각내지 않는다"를 설정이 아니라 규칙으로 만든다 (성적 동일, 손잡이 −1)

### DIFF
--- a/configs/schema.py
+++ b/configs/schema.py
@@ -349,7 +349,14 @@ class DecodeConfig(ModuleConfig):
     # 자유 구간이 원래 길이의 이 비율 이상이면 **중복이 아니라고 보고 원본을 그대로 둔다**.
     # 1.0 에 가까울수록 보수적(거의 포함된 선만 지운다). 0 이면 항상 잘라 낸다 —
     # 자르는 판은 f1 +5.5% 지만 recall −3.9% · 천장 0.946 -> 0.908 이라 **진짜 선을 지운다**.
+    # **`dedup_mode="ends"` 에서는 쓰이지 않는다** — 조각남을 규칙이 막으므로 게이트가 필요 없다.
+    # ablation(`dedup_mode=ratio`)에서만 산다.
     dedup_keep_ratio: float = 0.35
+    # 자르는 방식. "ratio" = 자유 구간을 조각으로 남기고 위 비율 게이트로 조각남을 막는다.
+    # "ends" = 겹친 **머리·꼬리만** 자르고 가운데는 건드리지 않는다 — 선 하나가 조각으로
+    # 갈라질 수 없으므로(1 -> 1 또는 0) 비율 게이트 없이도 재현율·천장이 안 깎인다.
+    # 비율 게이트는 LaneStitch 원본에 없던 전역 규칙이고, "ends" 는 같은 안전성을 국소로 낸다.
+    dedup_mode: str = "ends"
 
 
 @dataclass(kw_only=True)
@@ -370,6 +377,12 @@ class MetricConfig(ModuleConfig):
     # frag는 "조금이라도 겹치는" 예측을 다 세어 정확성이 높을수록 부풀려진다(E00에서 확인).
     # frag_strict는 그 GT를 이 비율 이상 덮는 조각만 센다 — 조각남의 정직한 측정치다.
     frag_min_cov: float = 0.1
+    # 성능에서 빼는 종류. **기본값이 빈 튜플이 아닌 이유**: `_cast_tuple` 이 원소 타입을
+    # 현재 값에서 읽으므로 `()` 로 두면 덮어쓴 값이 문자열로 남아 손잡이가 조용히 꺼진다.
+    # 0 = background 는 인스턴스가 없어 어차피 세지 않으므로 무동작이다.
+    # 8 = guiding_line 은 **선이 아니라 영역**이라 원래 선으로 찾을 대상이 아니다(사용자 08-26).
+    # 논문 성능을 그렇게 낼 때 `--set eval.exclude_classes=(0,8)` 로 켠다.
+    exclude_classes: tuple = (0,)
 
 
 @dataclass(kw_only=True)

--- a/gate_baseline.json
+++ b/gate_baseline.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2026-08-19",
+  "updated": "2026-08-26",
   "note": [
     "게이트는 고정된 검사 목록이 아니라 '지금까지 배운 실패 양식'의 누적이다.",
     "새로운 방식으로 깨지는 것을 볼 때마다 여기에 검사를 하나 추가한다 (SKILL 16절).",
@@ -127,6 +127,13 @@
       "assert": "[c + 0 for c in cfg.decode.short_classes] == [c for c in cfg.decode.short_classes]",
       "why": "튜플 손잡이를 `--set`/`--override` 로 덮어쓰면 `cast_like` 가 원소를 문자열로 남겨 그 손잡이가 **조용히 꺼진다**. 실제로 `decode.short_classes=(9,10,6,11,4)` 를 준 실험에서 원소가 '9' 가 되어 `label in short_classes`(int)가 영원히 거짓이 됐고, 짧은 차선 보호가 통째로 사라진 채 '희소 종류 보호는 효과 없음'으로 판정할 뻔했다. 실패가 예외가 아니라 무음이라 결과만 보면 알 수 없다 — 원소 타입을 여기서 못박는다 게이트 식은 builtins 가 비어 있어 `all`/`isinstance` 를 못 쓴다 — 원소에 0 을 더해 보는 것이 타입 검사다(문자열이면 TypeError 로 실패한다). 덮어쓰기 경로 자체는 `tests/test_build.py` 의 회귀 테스트가 지킨다(pytest 도 게이트다).",
       "since": "2026-08-19 (반경 축소 라운드에서 발견)"
+    },
+    {
+      "id": "exclude_classes_keeps_type",
+      "kind": "invariant",
+      "assert": "[c + 0 for c in cfg.eval.exclude_classes] == [c for c in cfg.eval.exclude_classes]",
+      "why": "`eval.exclude_classes` 는 논문 성능에서 종류를 빼는 손잡이다(guiding_line 은 선이 아니라 영역이라 원래 찾을 대상이 아니다). `short_classes` 와 **같은 함정**을 밟는다 — `_cast_tuple` 은 원소 타입을 **현재 값의 첫 원소**에서 읽으므로 기본값이 `()` 이면 덮어쓴 값이 문자열로 남고 `label in exclude_classes`(int) 가 영원히 거짓이 되어 **아무것도 안 빠진 채 '제외한 성능'으로 보고된다.** 그래서 기본값을 `(0,)`(background, 인스턴스가 없어 무동작)로 둔다 — 빈 튜플로 되돌리면 이 검사가 막는다.",
+      "since": "2026-08-26 (guiding_line 제외 손잡이 신설)"
     }
   ]
 }

--- a/stella/decode/dedup.py
+++ b/stella/decode/dedup.py
@@ -18,6 +18,17 @@
 
 거리 판정(이력 문턱·짧은 끊김 잇기)은 직전 연구 LaneStitch 의 벡터화 후처리에서 가져왔고,
 **간격을 메우는 단계를 뺐다.**
+
+**자르는 방식이 둘이다** (`dedup_mode`).
+
+    "ends"  — 겹친 **머리와 꼬리만** 잘라 낸다. 가운데는 건드리지 않으므로 선 하나가 조각으로
+              갈라질 수 없다: 인스턴스는 1개가 1개 또는 0개가 된다. 겹침이 가운데에 있는 것은
+              같은 차선 위 이중 그리기가 아니라 **교차**이므로 자르면 안 되는 것이다.
+    "ratio" — 자유 구간을 모두 조각으로 남기되, 자유 길이가 원본의 `keep_ratio` 이상이면
+              통째로 보존한다. 조각남을 그 **전역 비율 게이트**로 막는다.
+
+`ratio` 의 비율 게이트는 LaneStitch 원본에 없던 STELLA 추가분이고, `ends` 는 같은 안전성을
+**국소 규칙**으로 낸다 — 자르는 위치를 양 끝으로 제한하는 것만으로 조각남이 원천봉쇄된다.
 """
 
 import numpy as np
@@ -25,6 +36,8 @@ import numpy as np
 from stella.eval import geometry
 
 EPS = 1e-9
+ENDS_MODE = "ends"  # 머리·꼬리만 자른다 (조각남이 원천봉쇄된다)
+_EMPTY_STATS = {"dedup_dropped": 0, "dedup_joined": 0, "dedup_trimmed": 0}
 # 이어 붙인 결과의 최대 꺾임각이 원래 조각들보다 이만큼 넘게 나빠지면 갈래를 잘못 고른 것이다.
 BRANCH_SLACK_DEG = 20.0
 
@@ -43,6 +56,7 @@ class DuplicateResolver:
             join_gap=module_cfg.join_gap,
             step=module_cfg.step,
             keep_ratio=module_cfg.keep_ratio,
+            mode=module_cfg.mode,
             **kwargs,
         )
 
@@ -57,6 +71,7 @@ class DuplicateResolver:
         join_gap: float,
         step: float,
         keep_ratio: float,
+        mode: str,
     ):
         self.overlap_high = overlap_high
         self.overlap_low = overlap_low
@@ -66,12 +81,13 @@ class DuplicateResolver:
         self.join_gap = join_gap
         self.step = step
         self.keep_ratio = keep_ratio
+        self.mode = mode
 
     def __call__(self, instances: list[dict]) -> tuple[list[dict], dict]:
         """정리된 인스턴스와 진단 카운터를 낸다. 클래스별로 따로 처리한다."""
         if self.overlap_high <= 0.0 or len(instances) < 2:
-            return instances, {"dedup_dropped": 0, "dedup_joined": 0}
-        out, stats = [], {"dedup_dropped": 0, "dedup_joined": 0}
+            return instances, dict(_EMPTY_STATS)
+        out, stats = [], dict(_EMPTY_STATS)
         for label in sorted({int(item["class"]) for item in instances}):
             group = [item for item in instances if int(item["class"]) == label]
             out.extend(self._resolve_group(group, stats))
@@ -80,20 +96,43 @@ class DuplicateResolver:
     def _resolve_group(self, group: list[dict], stats: dict) -> list[dict]:
         """길이 내림차순으로 훑으며 이미 확정된 선과 겹치는 구간을 뺀다."""
         order = sorted(group, key=lambda it: _arc_length(it["points"]), reverse=True)
+        trim = self._trim_ends if self.mode == ENDS_MODE else self._trim_pieces
         kept: list[dict] = []
         for item in order:
-            pieces = self._free_pieces(item["points"], [k["points"] for k in kept])
-            if not pieces:
-                stats["dedup_dropped"] += 1
-                continue
-            if not kept:
-                kept.extend(dict(item, points=piece) for piece in pieces)
-                continue
-            if self._survives_whole(item, pieces):
-                kept.append(item)  # 상당 부분이 자유롭다 -> **자르지 않고 원본 그대로** 남긴다
-                continue
-            self._absorb(kept, item, pieces, stats)
+            trim(kept, item, stats)
         return kept
+
+    def _trim_ends(self, kept: list[dict], item: dict, stats: dict) -> None:
+        """겹친 **머리와 꼬리만** 잘라 낸다 — 가운데를 자르지 않아 조각으로 갈라지지 않는다.
+
+        가운데의 겹침은 같은 차선 위 이중 그리기가 아니라 **교차**다. 그것까지 자르면 진짜 선
+        하나가 둘로 갈라져 재현율이 떨어진다(08-20 실측: 재현율 −3.9% · GT 주입 천장 0.908).
+        자르는 위치를 양 끝으로 묶어 두면 그 사고가 규칙상 일어날 수 없다.
+        """
+        if not kept:
+            kept.append(item)  # 기준선 — 비교할 상대가 없다
+            return
+        pts, free = self._free_mask(item["points"], [k["points"] for k in kept])
+        span = _outer_span(pts, free)
+        if span is None or _arc_length(span) < self.min_free_len:
+            stats["dedup_dropped"] += 1
+            return
+        stats["dedup_trimmed"] += int(span.shape[0] < pts.shape[0])
+        kept.append(dict(item, points=span))
+
+    def _trim_pieces(self, kept: list[dict], item: dict, stats: dict) -> None:
+        """자유 구간을 모두 조각으로 남긴다. 조각남은 **전역 비율 게이트**로 막는다."""
+        pieces = self._free_pieces(item["points"], [k["points"] for k in kept])
+        if not pieces:
+            stats["dedup_dropped"] += 1
+            return
+        if not kept:
+            kept.extend(dict(item, points=piece) for piece in pieces)
+            return
+        if self._survives_whole(item, pieces):
+            kept.append(item)  # 상당 부분이 자유롭다 -> **자르지 않고 원본 그대로** 남긴다
+            return
+        self._absorb(kept, item, pieces, stats)
 
     def _survives_whole(self, item: dict, pieces: list[np.ndarray]) -> bool:
         """자유 구간이 원래 길이의 `keep_ratio` 이상이면 **중복이 아니다** — 원본을 그대로 둔다.
@@ -125,18 +164,24 @@ class DuplicateResolver:
 
     def _free_pieces(self, points, refs: list[np.ndarray]) -> list[np.ndarray]:
         """기준선들에서 가로 거리가 먼 구간만 남긴다. 남는 것이 없으면 '포함'이다."""
-        pts = _resample(np.asarray(points, dtype=np.float64), self.step)
+        pts, free = self._free_mask(points, refs)
         if pts.shape[0] < 2:
             return []
         if not refs:
             return [pts]
+        pieces = [pts[s:e] for s, e in _runs(free) if e - s >= 2]
+        return [p for p in pieces if _arc_length(p) >= self.min_free_len]
+
+    def _free_mask(self, points, refs: list[np.ndarray]) -> tuple[np.ndarray, np.ndarray]:
+        """재표본한 점열과 "기준선에서 떨어져 있다" 마스크. 두 자르기 방식이 공유한다."""
+        pts = _resample(np.asarray(points, dtype=np.float64), self.step)
+        if pts.shape[0] < 2 or not refs:
+            return pts, np.ones(pts.shape[0], dtype=bool)
         distance = np.full(pts.shape[0], np.inf)
         for ref in refs:
             distance = np.minimum(distance, _point_to_polyline(pts, ref))
         free = self._hysteresis(distance, pts)
-        free = _bridge(pts, free, self.bridge_gap)
-        pieces = [pts[s:e] for s, e in _runs(free) if e - s >= 2]
-        return [p for p in pieces if _arc_length(p) >= self.min_free_len]
+        return pts, _bridge(pts, free, self.bridge_gap)
 
     def _hysteresis(self, distance: np.ndarray, pts: np.ndarray) -> np.ndarray:
         """두 문턱 — 약한 이탈은 **강한 이탈이 일정 길이 이상 지속될 때만** 자유로 인정한다.
@@ -149,6 +194,14 @@ class DuplicateResolver:
             if _sustained(strong[start:end], pts[start:end], self.min_diverge_len):
                 free[start:end] = True
         return free
+
+
+def _outer_span(pts: np.ndarray, free: np.ndarray) -> np.ndarray | None:
+    """첫 자유 지점부터 마지막 자유 지점까지를 **한 덩어리로** 낸다. 자유가 없으면 None."""
+    index = np.flatnonzero(free)
+    if index.size < 2:
+        return None
+    return pts[index[0] : index[-1] + 1]
 
 
 def _sustained(strong: np.ndarray, pts: np.ndarray, min_len: float) -> bool:

--- a/stella/decode/graph.py
+++ b/stella/decode/graph.py
@@ -74,6 +74,7 @@ class ChainDecoder:
         dedup_join_gap: float,
         dedup_step: float,
         dedup_keep_ratio: float,
+        dedup_mode: str,
     ):
         if align_mode not in ALIGN_MODES:
             raise ValueError(f"align_mode 는 {ALIGN_MODES} 중 하나여야 한다: {align_mode}")
@@ -116,6 +117,7 @@ class ChainDecoder:
             join_gap=dedup_join_gap,
             step=dedup_step,
             keep_ratio=dedup_keep_ratio,
+            mode=dedup_mode,
         )
         self.stats = ChainStats()
 

--- a/stella/eval/ccq.py
+++ b/stella/eval/ccq.py
@@ -32,6 +32,7 @@ class InstanceCCQ(Metric):
             sample_step=module_cfg.sample_step,
             max_instances=module_cfg.max_instances,
             frag_min_cov=module_cfg.frag_min_cov,
+            exclude_classes=module_cfg.exclude_classes,
         )
 
     def __init__(
@@ -45,6 +46,7 @@ class InstanceCCQ(Metric):
         sample_step: float,
         max_instances: int,
         frag_min_cov: float,
+        exclude_classes: tuple,
     ):
         super().__init__()
         self.num_classes = num_classes
@@ -55,6 +57,7 @@ class InstanceCCQ(Metric):
         self.sample_step = sample_step
         self.max_instances = max_instances
         self.frag_min_cov = frag_min_cov
+        self.exclude_classes = tuple(int(label) for label in exclude_classes)
         for name in ("tp", "fp", "fn", "fp_redundant", "fp_spurious"):
             self.add_state(name, torch.zeros(num_classes), dist_reduce_fx="sum")
         for name in ("gt_covered", "gt_total", "pred_covered", "pred_total"):
@@ -160,7 +163,7 @@ class InstanceCCQ(Metric):
         self.frag_count += 1
 
     def compute(self) -> dict[str, torch.Tensor]:
-        tp, fp, fn = self.tp, self.fp, self.fn
+        tp, fp, fn = (self._counted(state) for state in (self.tp, self.fp, self.fn))
         precision = tp / (tp + fp).clamp(min=1e-9)
         recall = tp / (tp + fn).clamp(min=1e-9)
         f1 = 2 * precision * recall / (precision + recall).clamp(min=1e-9)
@@ -170,6 +173,19 @@ class InstanceCCQ(Metric):
         result |= self._aggregate_scores()
         result |= _per_class(f1, precision, recall, present)
         return result
+
+    def _counted(self, state: torch.Tensor) -> torch.Tensor:
+        """제외 종류의 칸을 0 으로 만든 사본. 전체 점수·종류별 평균·종류별 행에서 함께 빠진다.
+
+        `guiding_line` 처럼 **애초에 선이 아닌 것**(면으로 칠해진 영역)을 성능에서 빼기 위한
+        손잡이다. 종류별 점수를 평균에서 빼는 것만으로는 안 된다 — 전체 점수는 종류를 합쳐
+        세므로 **정답 쪽과 예측 쪽을 둘 다** 빼야 같은 판이 된다.
+        """
+        if not self.exclude_classes:
+            return state
+        kept = state.clone()
+        kept[list(self.exclude_classes)] = 0.0
+        return kept
 
     def _aggregate_scores(self) -> dict[str, torch.Tensor]:
         return {

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -147,3 +147,22 @@ def test_best_checkpoint_without_scores_returns_none(tmp_path):
     (run / "checkpoints").mkdir(parents=True)
     (run / "checkpoints" / "epoch000.ckpt").write_bytes(b"")
     assert runlog.best_checkpoint(run) is None
+
+
+def test_excluded_class_leaves_every_score():
+    """제외한 종류는 **전체 점수·종류별 평균·종류별 행에서 모두** 빠진다.
+
+    `guiding_line` 은 선이 아니라 영역이라 원래 선으로 찾을 대상이 아니다(사용자 08-26).
+    종류별 점수를 평균에서 빼는 것만으로는 부족하다 — 전체 점수는 종류를 합쳐 세므로
+    **정답 쪽과 예측 쪽을 둘 다** 빼야 한다.
+    """
+    truth = [line(10, 500, 100, label=3), line(10, 500, 300, label=8)]
+    kept = make_metric()
+    kept.update([dict(truth[0])], truth)  # 8번을 통째로 놓쳤다
+    dropped = make_metric(exclude_classes=(0, 8))
+    dropped.update([dict(truth[0])], truth)
+    assert float(kept.compute()["recall"]) == 0.5  # 둘 중 하나만 맞혔다
+    result = dropped.compute()
+    assert float(result["recall"]) == 1.0  # 8번을 빼면 남은 하나를 다 맞혔다
+    assert float(result["f1"]) == 1.0
+    assert not any(key.endswith("/guiding_line") for key in result)

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -199,6 +199,7 @@ def test_dedup_removes_contained_line_and_never_adds():
         join_gap=6.0,
         step=2.0,
         keep_ratio=0.35,
+        mode="ratio",
     )
     long_line = np.stack([np.arange(0, 200, 4.0), np.zeros(50)], axis=1)
     inside = np.stack([np.arange(40, 120, 4.0), np.full(20, 1.5)], axis=1)  # 1.5px 옆 = 중복
@@ -227,6 +228,7 @@ def test_dedup_never_bridges_a_gap():
         join_gap=6.0,
         step=2.0,
         keep_ratio=0.35,
+        mode="ratio",
     )
     first = np.stack([np.arange(0, 80, 4.0), np.zeros(20)], axis=1)
     far = np.stack([np.arange(200, 280, 4.0), np.zeros(20)], axis=1)  # 120px 떨어짐
@@ -275,6 +277,7 @@ def test_dedup_keeps_partially_free_line_whole():
         join_gap=6.0,
         step=2.0,
         keep_ratio=0.35,
+        mode="ratio",
     )
     base = np.stack([np.arange(0, 200, 4.0), np.zeros(50)], axis=1)
     half = np.stack([np.arange(100, 300, 4.0), np.full(50, 1.5)], axis=1)  # 절반만 겹친다
@@ -286,3 +289,79 @@ def test_dedup_keeps_partially_free_line_whole():
     )
     assert len(out) == 2
     assert any(len(item["points"]) == len(half) for item in out)  # 원본이 그대로 남았다
+
+
+def _ends_resolver(**overrides):
+    """머리·꼬리만 자르는 방식의 정리기. 문턱은 위 시험들과 같게 둔다."""
+    from stella.decode.dedup import DuplicateResolver
+
+    params = dict(
+        overlap_high=6.0,
+        overlap_low=3.0,
+        min_free_len=8.0,
+        bridge_gap=0.0,
+        min_diverge_len=0.0,
+        join_gap=6.0,
+        step=2.0,
+        keep_ratio=0.0,
+        mode="ends",
+    )
+    return DuplicateResolver(**(params | overrides))
+
+
+def test_dedup_ends_mode_never_fragments_a_crossing():
+    """가운데서 겹치는 선은 **한 개 그대로** 남는다 — 자르면 진짜 선이 둘로 갈라진다.
+
+    비율 게이트(keep_ratio) 없이도 성립해야 한다. 그것이 "머리·꼬리만 자른다"의 요점이다.
+    """
+    import numpy as np
+
+    base = np.stack([np.arange(0, 200, 4.0), np.zeros(50)], axis=1)
+    crossing = np.stack([np.full(50, 100.0), np.arange(-100, 100, 4.0)], axis=1)
+    out, stats = _ends_resolver()(
+        [
+            {"class": 3, "points": base, "score": 1.0},
+            {"class": 3, "points": crossing, "score": 1.0},
+        ]
+    )
+    assert len(out) == 2  # 조각으로 갈라지지 않았다
+    assert stats["dedup_dropped"] == 0
+
+
+def test_dedup_ends_mode_trims_only_the_overlapping_tail():
+    """꼬리만 겹친 선은 **짧아지되 하나로** 남는다 — 인스턴스 수는 그대로다."""
+    import numpy as np
+
+    base = np.stack([np.arange(0, 200, 4.0), np.zeros(50)], axis=1)
+    tail = np.stack([np.arange(100, 300, 4.0), np.full(50, 1.5)], axis=1)  # 앞 절반이 겹친다
+    out, _ = _ends_resolver()(
+        [
+            {"class": 3, "points": base, "score": 1.0},
+            {"class": 3, "points": tail, "score": 1.0},
+        ]
+    )
+    assert len(out) == 2
+    trimmed = min(out, key=lambda item: _length(item["points"]))
+    assert _length(trimmed["points"]) < _length(tail) - 50.0  # 겹친 앞부분이 잘렸다
+
+
+def test_dedup_ends_mode_still_drops_a_contained_line():
+    """완전히 포함된 선은 이 방식에서도 사라진다 — 자유 지점이 하나도 없다."""
+    import numpy as np
+
+    base = np.stack([np.arange(0, 200, 4.0), np.zeros(50)], axis=1)
+    inside = np.stack([np.arange(40, 120, 4.0), np.full(20, 1.5)], axis=1)
+    out, stats = _ends_resolver()(
+        [
+            {"class": 3, "points": base, "score": 1.0},
+            {"class": 3, "points": inside, "score": 1.0},
+        ]
+    )
+    assert len(out) == 1
+    assert stats["dedup_dropped"] == 1
+
+
+def _length(points) -> float:
+    import numpy as np
+
+    return float(np.linalg.norm(np.diff(np.asarray(points), axis=0), axis=1).sum())


### PR DESCRIPTION
## 요약

중복 선을 지우는 후처리에서 **자르는 위치를 선의 양 끝으로만 제한**하도록 바꿨다. 지금까지는
"겹친 구간을 뺀 나머지가 원본 길이의 35% 이상이면 그 선을 통째로 살린다"는 **전역 예외 규칙**
하나로 사고를 막고 있었는데, 그 규칙 없이 **알고리즘 자체가** 사고를 못 내게 만든 것이다.

성적은 **같다** — 최종 성적(f1) 0.3857 vs 기존 0.3860(−0.08%, 판정 밴드 ±2% 안), **천장**
(정답을 그대로 넣었을 때 나오는 상한) 0.9366 vs 0.9366, **중복 선 비율** 0.5% vs 0.5%.
값이 같으므로 **설정 손잡이가 하나 줄고 계약이 규칙으로 보장되는 쪽**을 택한다.

곁들여 `eval.exclude_classes` 를 넣었다 — 성능 계산에서 특정 차선 종류를 통째로 빼는 손잡이다.
`guiding_line`(유도선)이 **선이 아니라 면으로 칠해진 영역**이라 애초에 선으로 찾을 대상이
아님이 확인돼(2026-08-26), 논문 성능을 그것 없이 낼 수 있어야 하기 때문이다.

## 왜 이 실험을 했나

중복 선 정리(**dedup** — 같은 차선 위에 두 번 그려진 선을 지우거나 끝에서 잇는 후처리)는
직전 연구 LaneStitch 의 후처리에서 가져왔다. 그런데 STELLA 는 원본에 **없던 규칙**을 하나
더 얹고 있었다 — `dedup_keep_ratio`(자유 비율 보존 문턱, 기본 0.35): 겹치지 않은 부분이
원본 길이의 35% 이상이면 **자르지 않고 통째로 남긴다.**

그 규칙이 왜 필요했나. 2026-08-20 실측에서 **항상 자르는 판**은 정밀도를 올리는 대신
**재현율을 3.9% 깎고 천장을 0.946 → 0.908 로 무너뜨렸다.** 정답에는 중복이 없으므로 그
4%는 **진짜 선을 지운 것**이다. 원인은 **조각남**이다 — 두 선이 가운데서 교차할 때 자르기가
진짜 선 하나를 둘로 갈라 버린다.

**가설.** 자르는 **위치**를 양 끝으로 제한하면, 전역 비율 규칙 없이도 조각남이 안 생긴다.
**그렇게 본 근거.** 가운데의 겹침은 같은 차선 위 이중 그리기가 아니라 **교차**다. 이중 그리기는
선의 머리나 꼬리가 남의 선 위에 얹히는 모양으로 나타난다. 즉 **지워야 할 것은 끝에 있고
지우면 안 되는 것은 가운데에 있다.**
**반증 조건.** 천장이 내려가거나 재현율이 밴드(±2%) 밖으로 떨어지면 기각. 그 둘이 08-20 에
실제로 사고를 잡아낸 지표다.
**미리 정한 지목 지표.** ① 천장 ② 재현율 ③ 중복 선 비율. 최종 성적은 맨 마지막에 본다.

## 무엇을 어떻게 바꿨나

| 조건 | 무엇을 바꿨나 | 평범한 말로 | 왜 효과가 있을 것이라 봤나 |
| --- | --- | --- | --- |
| **ends** (채택) | `decode.dedup_mode` **"ratio" → "ends"** | 겹친 **머리와 꼬리만** 잘라 내고 가운데는 손대지 않는다 | 선 하나가 조각으로 갈라질 수 **없다**(1개 → 1개 또는 0개). 사고의 원인이 규칙상 사라진다 |
| ratio + keep 0 | `dedup_keep_ratio` **0.35 → 0** | 예외 없이 **항상 자른다** (LaneStitch 원본 동작) | 08-20 에 재현율을 깎던 판. 지금도 그런지 확인용 |
| ends + 완만 | `dedup_min_diverge` **8 → 16** | "떨어졌다"고 인정하려면 16 px 이상 떨어져 있어야 한다 | 경계를 더 보수적으로 그으면 덜 자를 것이다 |

## 실험 조건

| 항목 | 값 |
| --- | --- |
| 규격 | **D 규격(디코더 전용 실험)** — 학습 없이, 저장해 둔 예측을 디코더로 다시 잇기만 한다. GPU 불필요 |
| 예측 | `F01_val_full` — 전체 데이터로 학습한 현재 최고 모델의 검증셋 예측 캐시 중 **400장** |
| 천장 | `gt_val_full` — **정답을 그대로 모델 출력 자리에 넣은** 캐시 중 **400장** (같은 400장) |
| 중복 선 비율 | 같은 캐시 **120장** (기존 측정과 장수를 맞췄다) |
| 대조군 | `dedup_mode="ratio"`, `keep_ratio=0.35`, `min_diverge=8` — **현재 채택값**(PR #26~31) |
| 판정 밴드 | **±2%** (같은 설정을 두 번 돌렸을 때의 차이가 0.1% 라 그 20배로 잡았다) |

## 결과

**읽는 법.** **천장부터 본다.** 천장이 내려갔다면 그 판은 진짜 선을 지운 것이라 최종 성적이
올랐어도 기각이다. 그 다음이 재현율, 최종 성적은 맨 마지막이다.

| 조건 | 천장 ↑ | 재현율 ↑ | 정밀도 ↑ | f1 ↑ | 중복 선 ↓ | 장당 선 수 |
| --- | --- | --- | --- | --- | --- | --- |
| **ratio 0.35 (현행)** | 0.9368 | 0.3202 | 0.4859 | 0.3860 | 0.5% | 27.1 |
| **ends (채택)** | **0.9366** | **0.3200** | 0.4853 | **0.3857** | **0.5%** | **27.1** |
| ratio + keep 0 (항상 자르기) | — | 0.3197 | 0.4836 | 0.3849 | — | — |
| ends + min_diverge 16 | **0.9220** | 0.3136 | 0.4929 | 0.3833 | — | — |

**각 열이 무엇인가**

| 열 | 뜻 |
| --- | --- |
| **천장 (ceiling, GT 주입)** | 모델이 완벽하다고 가정했을 때 나오는 점수. 정답을 그대로 모델 출력 형식에 넣고 디코더만 돌려 잰다. **어떤 모델도 이보다 잘할 수 없다** |
| **재현율 (recall)** | 정답 선 중 짝이 맞는 예측이 있는 비율 |
| **정밀도 (precision)** | 예측한 선 중 정답과 짝이 맞은 비율 |
| **f1** | 재현율과 정밀도를 하나로 합친 **최종 성적** |
| **중복 선 비율** | 같은 종류의 다른 예측선과 **자기 길이의 80% 이상이 8 px 안에서 나란히** 가는 예측선의 비율. 후처리 전에는 12.9% 다 |

## 무엇이 보이는가

1. **새 방식은 현행과 구별되지 않는다.** 천장 −0.02%, 재현율 −0.06%, 최종 성적 −0.08% —
   전부 판정 밴드(±2%)의 1/20 안이다. 중복 제거 능력도 같다(0.5% vs 0.5%, 장당 선 수 27.1 로 동일).
   **그러면 무엇이 달라졌나**: 조각남을 막는 근거가 "설정값 0.35" 에서 **"규칙상 불가능"** 으로 옮겼다.

2. **★ 08-20 의 "항상 자르면 재현율 −3.9%" 가 지금은 재현되지 않는다.** 같은 조건
   (`keep_ratio=0`)에서 재현율 0.3197 vs 현행 0.3202 — **−0.2%** 다. 그때는 디코더 탐색 반경이
   12 셀이라 사슬이 **이웃 차선으로 갈아타** 서로 겹치는 선을 많이 만들고 있었고, 자르기가
   그 겹침을 진짜 선에서 잘라 내고 있었다. 반경을 5로 줄인 뒤로 **가려 주던 안전장치가 더
   이상 필요 없어졌다.** "파라미터를 고치면 그것이 가리던 축이 되살아난다"의 **반대 방향** 사례다.

3. **경계를 더 보수적으로 그으면 오히려 나빠진다.** `min_diverge` 를 8 → 16 으로 올리면
   정밀도는 0.4853 → 0.4929 로 오르지만 **천장이 0.9366 → 0.9220 으로 1.6% 내려간다.**
   덜 자르는 게 아니라 **자유 구간으로 인정되는 조각이 줄어 선이 통째로 버려진 것**이다.
   지목 지표를 천장으로 잡아 두지 않았으면 "정밀도가 올랐다"로 채택할 뻔했다. 8 을 유지한다.

4. **내 예측이 반쯤 빗나갔다.** 새 방식이 중복을 **더** 잘 지울 것이라고 봤는데(전역 예외에
   걸려 살아남던 중복이 잘릴 것이므로) 실제로는 완전히 같았다. 지금 남아 있는 중복 0.5% 는
   이 단계가 아니라 **정점 비최대 억제**가 이미 걸러 낸 뒤의 잔량이다.

## 판정

**채택.** 판정 기준은 "천장이 안 내려가고 재현율이 밴드(±2%) 안이면서 최종 성적이 오르거나
같을 것" 이었고 셋 다 만족한다. 성적이 같을 때 **더 단순한 쪽**을 택한다는 것이 이 채택의
근거다 — 손잡이가 하나 죽고, 후처리 계약("선 개수는 줄기만 한다")이 설정이 아니라 알고리즘의
성질이 된다. 논문에서 그 계약을 **주장이 아니라 증명**으로 쓸 수 있다.

## 무엇을 바꾸는가 (이 PR의 변경)

| 파일 | 무엇을 · 왜 |
| --- | --- |
| `stella/decode/dedup.py` | `_trim_ends` 신설 — 첫 자유 지점부터 마지막 자유 지점까지를 한 덩어리로 남긴다. 기존 동작은 `_trim_pieces` 로 이름만 옮겨 그대로 살아 있다. 두 방식이 `_free_mask` 를 공유한다 |
| `configs/schema.py` | `decode.dedup_mode` 신설(기본 **"ends"**). `dedup_keep_ratio` 는 `"ratio"` 방식에서만 쓰이며 논문 ablation 을 위해 남긴다 |
| `stella/decode/graph.py` | 새 손잡이를 디코더에 배선 |
| `tests/test_postprocess.py` | 시험 3개 — ① 가운데서 교차하는 선이 **조각으로 갈라지지 않는다** ② 꼬리만 겹친 선은 **짧아지되 하나로** 남는다 ③ 완전히 포함된 선은 이 방식에서도 사라진다 |

**딸린 변경 — 성능에서 종류를 빼는 손잡이**

| 파일 | 무엇을 · 왜 |
| --- | --- |
| `stella/eval/ccq.py` | `exclude_classes` — 제외 종류의 칸을 0 으로 만들어 **전체 점수·종류별 평균·종류별 행에서 함께** 뺀다. 종류별 점수를 평균에서 빼는 것만으로는 안 된다: 전체 점수는 종류를 합쳐 세므로 **정답 쪽과 예측 쪽을 둘 다** 빼야 같은 판이 된다 |
| `configs/schema.py` | `eval.exclude_classes` 기본 **`(0,)`**. 빈 튜플이 아닌 이유는 덮어쓰기 형변환이 원소 타입을 **현재 값의 첫 원소**에서 읽기 때문이다 — `()` 로 두면 덮어쓴 값이 문자열로 남아 손잡이가 **조용히 꺼진다**. 0(배경)은 인스턴스가 없어 무동작이다 |
| `gate_baseline.json` | 그 함정을 막는 검사 `exclude_classes_keeps_type` 추가. 같은 함정을 `short_classes` 에서 한 번 밟았다 |
| `tests/test_metric.py` | 제외한 종류가 전체 점수·평균·종류별 행에서 모두 빠지는지 |

## 검증

**병합 전 관문(`scripts/gate.py`) 13종 전부 통과 · 실패 0.** 400장에서 본 결과가
**전체 검증셋 1,282장에서 그대로 재현됐다.**

| 검사 | 결과 | 하한 | 무엇을 막나 |
| --- | --- | --- | --- |
| **ceiling_gt** (천장) | **0.9403** | 0.93 | 후처리가 **진짜 선을 지우는 것**. 08-14 에 이 검사가 실제로 사고를 잡았다 |
| **model_regress** (모델 회귀) | **0.4299** | 하한 통과 | 천장은 멀쩡한데 모델 성적만 무너지는 변경 |
| pytest 136종 · ruff · format · configs · install | 통과 | — | 계약·린트·설정 오타·설치 위치 |
| `exclude_classes_keeps_type` (신설) | 통과 | — | 빈 튜플 기본값이 손잡이를 조용히 끄는 것 |
| 그 밖 4종 | 통과 | — | 디코더 비용·큐 형식·평가 버퍼·전경 헤드 |

기존 기준값은 천장 **0.9410** · 모델 **0.4303** 이었다. 각각 **−0.07% · −0.09%** 로
판정 밴드(±2%)의 1/20 안이다.

## 이 결과의 한계

- 스윕은 400장에서 쟀다. 게이트가 **1,282장 전체**로 다시 재서 같은 결론을 확인했다(위 검증 절).
- **모델 하나(F01)의 예측에서만 쟀다.** 모델이 달라지면 중복의 양상도 달라질 수 있다.
- **`guiding_line` 을 뺀 성능은 아직 수치를 안 냈다.** 손잡이만 넣었고, 실제 값은 따로 잰다.
- 학습 쪽은 이 PR과 무관하다. 전체 데이터 학습 두 판(짧은 선 가중 / 큰 백본)이 별도로 돌고 있다.

## 다음 실험 계획

**실험은 오늘로 끝난다**(사용자 지시 08-26). 남은 것은 밤새 도는 전체 데이터 학습 두 판의
채점뿐이다 — ① 짧은 선에 손실 가중을 주는 처방, ② 거기에 더해 영상 특징 추출기를 큰 것으로
바꾼 판. 두 판 모두 기준선 **F02(0.4229)** 및 현재 최고 **F01(0.4303)** 과 같은 판(검증
1,282장)에서 잰다. 그 뒤로는 논문 작성만 한다.
